### PR TITLE
Add a link to the installation instructions

### DIFF
--- a/content/learn/index.md
+++ b/content/learn/index.md
@@ -16,6 +16,10 @@ Think you've found a bug? It's quite possible. Pony is a relatively young langua
 
 The Pony community while small is very helpful and inviting. We think you'll find interacting with us to be an enjoyable experience. You can find a lot more community-related resources in the [community section](/community) of this site. 
 
+## Installing Pony
+
+Ready to dive into Pony? Excellent! Please checkout the [installation instructions](https://github.com/ponylang/ponyc/blob/master/README.md#installation) for the ponyc compiler.
+
 ## Getting started
 
 We have a couple resources designed to help you learn, we suggest starting with the tutorial and from there, moving on to the Pony Patterns book. Additionally, standard library documentation is available online.


### PR DESCRIPTION
These instructions are already linked in the tutorial, but I think it makes
sense to have them on the main site as well, since it is easier to find quickly.