### PR TITLE
Improvements to lldb cheatsheet

### DIFF
--- a/content/reference/pony-lldb-cheatsheet.md
+++ b/content/reference/pony-lldb-cheatsheet.md
@@ -65,16 +65,19 @@ If you would like to limit the size of the backtrace (for example, when you are 
 
 ```bash
 (lldb) thread backtrace --count 5
-(lldb) b -c 5
+(lldb) bt -c 5
 ```
 
 ### Stepping
 
 ```bash
 (lldb) thread step-in
+(lldb) s
+(lldb) sif funToStepInto
 (lldb) thread step-over
+(lldb) n
 (lldb) thread step-out
-(lldb) thread step-into
+(lldb) finish
 (lldb) thread until LINE
 ```
 

--- a/content/reference/pony-lldb-cheatsheet.md
+++ b/content/reference/pony-lldb-cheatsheet.md
@@ -65,7 +65,7 @@ If you would like to limit the size of the backtrace (for example, when you are 
 
 ```bash
 (lldb) thread backtrace --count 5
-(lldb) bt -c 5
+(lldb) bt 5
 ```
 
 ### Stepping


### PR DESCRIPTION
This proposes a couple fixes and improvements to the lldb cheatsheet, which I saw thanks to this mention https://twitter.com/SeanTAllen/status/1092602995177594880.

* Fixes a `bt` typo
* Removes `thread step-into`, which doesn't exist
* Adds stepping aliases `s`, `n`, and `finish`
* Adds `sif` to the section on stepping, which steps into a named function
