### PR TITLE
Remove Google+ from sharing options

### DIFF
--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -9,8 +9,4 @@
         onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
         <i class="fa fa-2x fa-fw fa-facebook-square" style="margin-left: -8px"></i> <span class="hidden">Facebook</span>
     </a>
-    <a href="https://plus.google.com/share?url={{ .Permalink }}" title="Share on Google+"
-       onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-        <i class="fa fa-2x fa-fw fa-google-plus-square" style="margin-left: -8px"></i> <span class="hidden">Google+</span>
-    </a>
 </section>


### PR DESCRIPTION
It will be deactivated on April 2nd, 2019