### PR TITLE
Remove most groups.io references

### DIFF
--- a/archetypes/lwip.md
+++ b/archetypes/lwip.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - Month Day, Year"
 date = "{{ .Date }}"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/0.16.0-released.md
+++ b/content/blog/0.16.0-released.md
@@ -53,7 +53,7 @@ for compliance with the new syntax requirement.
   [https://gist.github.com/kulibali/cd5caf3a32d510bb86412f3fd4d52d0f](https://gist.github.com/kulibali/cd5caf3a32d510bb86412f3fd4d52d0f)
 
 If you need any other assistance with this transition, please reach out to
-us on [the mailing list](https://pony.groups.io/g/user). We're here to help!
+us. We're here to help!
 
 ### Fixed
 

--- a/content/blog/last-week-in-pony-01072018.md
+++ b/content/blog/last-week-in-pony-01072018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - January 07, 2018"
 date = "2018-01-07T17:30:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang). 
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -24,7 +24,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 The first Development Sync Call this year happened on January 3rd this year, just in time. Check out the [audio recording](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_01_03).
 
-The next one is scheduled for Wednesday, January 10, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, January 10, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-011419.md
+++ b/content/blog/last-week-in-pony-011419.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - January 14, 2019"
 date = "2019-01-14T15:29:04-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io) or our Twitter account [@ponylang](https://twitter.com/ponylang).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-01142018.md
+++ b/content/blog/last-week-in-pony-01142018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - January 14, 2018"
 date = "2018-01-14T12:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -31,7 +31,7 @@ Kristoffer Grönlund is talking about Pony at [linux.conf.au](https://linux.conf
 
 Another Sync call took place on Wednesday January 10, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_01_10).
 
-The next one is scheduled for Wednesday, January 17, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, January 17, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-012019.md
+++ b/content/blog/last-week-in-pony-012019.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - January 20, 2019"
 date = "2019-01-20T10:03:08-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-01212018.md
+++ b/content/blog/last-week-in-pony-01212018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - January 21, 2018"
 date = "2018-01-21T20:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -32,7 +32,7 @@ Upgrading as soon as possible is recommended.
 
 Another Sync call took place on Wednesday January 17, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_01_17).
 
-The next one is scheduled for Wednesday, January 24, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, January 24, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-012719.md
+++ b/content/blog/last-week-in-pony-012719.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - January 27, 2019"
 date = "2019-01-27T11:47:27-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-01282018.md
+++ b/content/blog/last-week-in-pony-01282018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - January 28, 2018"
 date = "2018-01-28T20:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -16,7 +16,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 ## Items of note
 
-- James Bracey wrote to the [user list](https://pony.groups.io/g/user) to let us all know about a [Pony Cassandra client](https://github.com/waratuman/pony-cql) he started. It's in early stages and it doesn't sound like he's planning on doing more work at this time, but he wanted to let folks know. Full mailing list message can be viewed at: https://pony.groups.io/g/user/message/1577
+- James Bracey wrote to the user list to let us all know about a [Pony Cassandra client](https://github.com/waratuman/pony-cql) he started. It's in early stages and it doesn't sound like he's planning on doing more work at this time, but he wanted to let folks know. Full mailing list message can be viewed at: https://pony.groups.io/g/user/message/1577
 
 ## Talks
 
@@ -26,7 +26,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 Another Sync call took place on Wednesday January 24, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_01_24).
 
-The next one is scheduled for Wednesday, January 31, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, January 31, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-020319.md
+++ b/content/blog/last-week-in-pony-020319.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 3, 2019"
 date = "2019-02-03T10:57:24-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-02042018.md
+++ b/content/blog/last-week-in-pony-02042018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 04, 2018"
 date = "2018-02-04T18:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -20,14 +20,14 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 - A new JSON parser for Pony has been announced on reddit: https://github.com/Krognol/ponyjson
 
-- [PR #2439](https://github.com/ponylang/ponyc/pull/2439) for embedding source code listings into generated documentation has been merged to master. With this change, we now own a new theme for mkdocs, [mkdocs-ponylang](https://github.com/mfelsche/ponylang-mkdocs-theme). We needed this to make the necessary changes for [PR #2439](https://github.com/ponylang/ponyc/pull/2439) but we are not yet happy with its current state (visually and code-wise). We want to reach out to you folks for help on this project. In case you are interested, please drop us a line via the [Pony mailing list](https://pony.groups.io/g/user/). Any help is much appreciated!
+- [PR #2439](https://github.com/ponylang/ponyc/pull/2439) for embedding source code listings into generated documentation has been merged to master. With this change, we now own a new theme for mkdocs, [mkdocs-ponylang](https://github.com/mfelsche/ponylang-mkdocs-theme). We needed this to make the necessary changes for [PR #2439](https://github.com/ponylang/ponyc/pull/2439) but we are not yet happy with its current state (visually and code-wise). We want to reach out to you folks for help on this project. In case you are interested, please drop us a line via the [Zulip community](https://ponylang.zulipchat.com/#narrow/stream/190361-main.2Eactor). Any help is much appreciated!
 
 
 ## Pony Development Sync
 
 Another Sync call took place on Wednesday January 31, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_01_31).
 
-The next one is scheduled for Wednesday, February 7, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, February 7, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-021019.md
+++ b/content/blog/last-week-in-pony-021019.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 10, 2019"
 date = "2019-02-10T11:03:32-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-02112018.md
+++ b/content/blog/last-week-in-pony-02112018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 11, 2018"
 date = "2018-02-11T20:30:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -21,7 +21,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 The Pony developers met on their weekly sync call on Wednesday February 7, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_02_07).
 
-The next one is scheduled for Wednesday, February 14, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, February 14, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-021719.md
+++ b/content/blog/last-week-in-pony-021719.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 17, 2019"
 date = "2019-02-17T09:19:15-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-02182018.md
+++ b/content/blog/last-week-in-pony-02182018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 18, 2018"
 date = "2018-02-18T16:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -27,7 +27,7 @@ But hey, let's all take the time to watch the following gif of a work-in-progres
 
 ## Pony Development Sync
 
-The next one is scheduled for Wednesday, February 21, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, February 21, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-022419.md
+++ b/content/blog/last-week-in-pony-022419.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 24, 2019"
 date = "2019-02-24T10:33:47-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-02252018.md
+++ b/content/blog/last-week-in-pony-02252018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - February 25, 2018"
 date = "2018-02-25T21:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -17,7 +17,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 The Pony developers met on their weekly sync call on Wednesday February 21, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_02_21).
 
-The next one is scheduled for Wednesday, February 28, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, February 28, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 
 ## RFCs

--- a/content/blog/last-week-in-pony-030319.md
+++ b/content/blog/last-week-in-pony-030319.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - March 3, 2019"
 date = "2019-03-03T10:58:13-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-03042018.md
+++ b/content/blog/last-week-in-pony-03042018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - March 04, 2018"
 date = "2018-03-04T21:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -43,7 +43,7 @@ This one is about generic primitives.
 
 The Pony developers met on their weekly sync call on Wednesday February 28, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_02_28).
 
-The next one is scheduled for Wednesday, March 07, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, March 07, 2018 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 
 ## RFCs

--- a/content/blog/last-week-in-pony-031019.md
+++ b/content/blog/last-week-in-pony-031019.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - March 10, 2019"
 date = "2019-03-10T11:19:46-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-03112018.md
+++ b/content/blog/last-week-in-pony-03112018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - March 11, 2018"
 date = "2018-03-11T10:09:41-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-031719.md
+++ b/content/blog/last-week-in-pony-031719.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - March 17, 2019"
 date = "2019-03-17T10:35:42-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user), or our [Zulip community](https://ponylang.zulipchat.com).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-03182018.md
+++ b/content/blog/last-week-in-pony-03182018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - March 18, 2018"
 date = "2018-03-18T19:10:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-03252018.md
+++ b/content/blog/last-week-in-pony-03252018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - March 25, 2018"
 date = "2018-03-25T20:40:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -29,7 +29,7 @@ In case you want to submit one (which I highly recommend), just add it as a comm
 
 The Pony developers met on their weekly sync call on Wednesday March 21, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_03_21).
 
-The next one is scheduled for Wednesday, February 28, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, February 28, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-032817.md
+++ b/content/blog/last-week-in-pony-032817.md
@@ -7,7 +7,7 @@ tags = []
 title = "Last Week in Pony - March 28, 2017"
 description = "Last week's Pony news, reported this week."
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-04022018.md
+++ b/content/blog/last-week-in-pony-04022018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - April 02, 2018"
 date = "2018-04-02T21:30:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -22,7 +22,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 The Pony developers met on their weekly sync call on Wednesday March 28, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_03_28).
 
-The next one is scheduled for Wednesday, April 04, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, April 04, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-040417.md
+++ b/content/blog/last-week-in-pony-040417.md
@@ -7,7 +7,7 @@ tags = []
 title = "Last Week in Pony - April 3, 2017"
 description = "Last week's Pony news, reported this week."
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-04082018.md
+++ b/content/blog/last-week-in-pony-04082018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - April 08, 2018"
 date = "2018-04-08T21:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -33,7 +33,7 @@ In case you want to submit one (which I highly recommend), just add it as a comm
 
 The Pony developers met on their weekly sync call on Wednesday April 04, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_04_04).
 
-The next one is scheduled for Wednesday, April 11, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, April 11, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-041117.md
+++ b/content/blog/last-week-in-pony-041117.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - April 10, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -41,7 +41,6 @@ ponylang.io was moved from being hosted on GitHub pages to being on Netlify: HTT
 - [Audio from the April 5th Pony Developer Sync](https://pony.groups.io/g/dev/files/Pony%20Sync/April%205,%202017) is available
 
 Interested in how Pony gets developed? What's going on? What the developers are up to? Check out audio from our weekly meeting. Btw, it open to the public!
-There's a [calendar](https://pony.groups.io/g/dev/calendar) and everything.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-04152018.md
+++ b/content/blog/last-week-in-pony-04152018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - April 15, 2018"
 date = "2018-04-15T22:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -23,7 +23,7 @@ Github user [EpicEric](https://github.com/EpicEric) completely refurbished the t
 
 The Pony developers met on their weekly sync call on Wednesday April 11, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_04_11).
 
-The next one is scheduled for Wednesday, April 18, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, April 18, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-041717.md
+++ b/content/blog/last-week-in-pony-041717.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - April 17, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -30,7 +30,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 ## News and Blog Posts
   
-- Audio from the April 12th Pony developer's sync is available at [https://pony.groups.io/g/dev/files/Pony%20Sync/April%2012,%202017](https://pony.groups.io/g/dev/files/Pony%20Sync/April%2012,%202017). The call was devoted mostly to addressing older issues that had started to back up. If you'd like to get involved with Pony development, feel free to stop by. We meet [weekly](https://pony.groups.io/g/dev/calendar).
+- Audio from the April 12th Pony developer's sync is available at [https://pony.groups.io/g/dev/files/Pony%20Sync/April%2012,%202017](https://pony.groups.io/g/dev/files/Pony%20Sync/April%2012,%202017). The call was devoted mostly to addressing older issues that had started to back up. If you'd like to get involved with Pony development, feel free to stop by. We meet [weekly](https://calendar.google.com/calendar?cid=NTlqY3J1NmY1MG1ycHFibTdlbTRpY2xua2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
 - Core team member [Sean T. Allen](https://twitter.com/seantallen) announced that he'll be giving two different Pony talks in the coming months. One at [PolyConf](https://polyconf.com) in July, the other at [QConNewYork](https://qconnewyork.com/ny2017/presentation/pony-fintech-experience-report) in June.
 

--- a/content/blog/last-week-in-pony-04222018.md
+++ b/content/blog/last-week-in-pony-04222018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - April 22, 2018"
 date = "2018-04-22T21:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -17,7 +17,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 The Pony developers met on their weekly sync call on Wednesday April 18, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_04_18).
 
-The next one is scheduled for Wednesday, April 25, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, April 25, 2018 at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-042417.md
+++ b/content/blog/last-week-in-pony-042417.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - April 23, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-04292018.md
+++ b/content/blog/last-week-in-pony-04292018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - April 29, 2018"
 date = "2018-04-29T09:30:19-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -36,7 +36,7 @@ And there's a ton more as well. Stop by the [developer mailing list](https://pon
 
 The Pony developers met on their weekly sync call on Wednesday, April 25, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_04_25).
 
-The next one is scheduled for Wednesday, May 2, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, May 2, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 
 ## RFCs

--- a/content/blog/last-week-in-pony-043017.md
+++ b/content/blog/last-week-in-pony-043017.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - April 30, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-05062018.md
+++ b/content/blog/last-week-in-pony-05062018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - May 6, 2018"
 date = "2018-05-06T21:30:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -21,7 +21,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 The Pony developers met on their weekly sync call on Wednesday, May 2, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_05_02).
 
-The next one is scheduled for Wednesday, May 9, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, May 9, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 
 ## RFCs

--- a/content/blog/last-week-in-pony-050717.md
+++ b/content/blog/last-week-in-pony-050717.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - May 7, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-05132018.md
+++ b/content/blog/last-week-in-pony-05132018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - May 13, 2018"
 date = "2018-05-13T21:40:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -17,7 +17,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 The Pony developers met on their weekly sync call on Wednesday, May 9, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_05_09).
 
-The next one is scheduled for Wednesday, May 16, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, May 16, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 
 ## RFCs

--- a/content/blog/last-week-in-pony-051417.md
+++ b/content/blog/last-week-in-pony-051417.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - May 14, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-05202018.md
+++ b/content/blog/last-week-in-pony-05202018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - May 20, 2018"
 date = "2018-05-20T22:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-052117.md
+++ b/content/blog/last-week-in-pony-052117.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - May 21, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-05272018.md
+++ b/content/blog/last-week-in-pony-05272018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - May 27, 2018"
 date = "2018-05-27T22:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -49,7 +49,7 @@ That has been quite a busy week, especially for Sean T. Allen. Big thanks for do
 
 The Pony developers met on their weekly sync call on Wednesday, May 23, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_05_23).
 
-The next one is scheduled for Wednesday, May 30, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, May 30, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-052817.md
+++ b/content/blog/last-week-in-pony-052817.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - May 28, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-06032018.md
+++ b/content/blog/last-week-in-pony-06032018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - June 3, 2018"
 date = "2018-06-03T21:30:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-060417.md
+++ b/content/blog/last-week-in-pony-060417.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - June 4, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-06102018.md
+++ b/content/blog/last-week-in-pony-06102018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - June 10, 2018"
 date = "2018-06-10T20:30:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -60,7 +60,7 @@ We are very proud to present you two new distribution channels for both [ponyc](
 
 The Pony developers met on their weekly sync call on Wednesday, June 6, 2018. Check out the [recorded audio](https://pony.groups.io/g/dev/files/Pony%20Sync/2018_06_06).
 
-The next one is scheduled for Wednesday, June 13, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+The next one is scheduled for Wednesday, June 13, 2018, at 03:30 PM (GMT-04:00) America/New York via zoom. We'd love to have you there.
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-061117.md
+++ b/content/blog/last-week-in-pony-061117.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - June 11, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-061817.md
+++ b/content/blog/last-week-in-pony-061817.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - June 18, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-06182018.md
+++ b/content/blog/last-week-in-pony-06182018.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - June 18, 2018"
 date = "2018-06-18T15:30:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-062517.md
+++ b/content/blog/last-week-in-pony-062517.md
@@ -8,7 +8,7 @@ draft: false
 title: Last Week in Pony - June 25, 2017
 ---
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-070118.md
+++ b/content/blog/last-week-in-pony-070118.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - July 1, 2018"
 date = "2018-07-01T23:46:51-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-070217.md
+++ b/content/blog/last-week-in-pony-070217.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - July 2, 2017"
 date = "2017-07-02T00:00:00-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-070917.md
+++ b/content/blog/last-week-in-pony-070917.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - July 9, 2017"
 date = "2017-07-09T07:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-071518.md
+++ b/content/blog/last-week-in-pony-071518.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - July 15, 2018"
 date = "2018-07-15T13:55:55-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-071617.md
+++ b/content/blog/last-week-in-pony-071617.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - July 16, 2017"
 date = "2017-07-16T06:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-072218.md
+++ b/content/blog/last-week-in-pony-072218.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - July 22, 2018"
 date = "2018-07-22T19:54:41-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-072317.md
+++ b/content/blog/last-week-in-pony-072317.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - July 23, 2017"
 date = "2017-07-23T00:00:01-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-072918.md
+++ b/content/blog/last-week-in-pony-072918.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - July 29, 2018"
 date = "2018-07-29T22:16:40-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-073017.md
+++ b/content/blog/last-week-in-pony-073017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - July 30, 2017"
 date = "2017-07-30T06:00:00-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-080518.md
+++ b/content/blog/last-week-in-pony-080518.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - August 5, 2018"
 date = "2018-08-05T19:14:57-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-080617.md
+++ b/content/blog/last-week-in-pony-080617.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - August 6, 2017"
 date = "2017-08-06T07:00:00-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-081218.md
+++ b/content/blog/last-week-in-pony-081218.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - August 12, 2018"
 date = "2018-08-12T20:46:37-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-081317.md
+++ b/content/blog/last-week-in-pony-081317.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - August 13, 2017"
 date = "2017-08-13T07:00:00-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-081918.md
+++ b/content/blog/last-week-in-pony-081918.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - August 19, 2018"
 date = "2018-08-19T21:12:22-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-082017.md
+++ b/content/blog/last-week-in-pony-082017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - August 20, 2017"
 date = "2017-08-20T07:00:00-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is:issue+is:open+label:last-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-082618.md
+++ b/content/blog/last-week-in-pony-082618.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - August 26, 2018"
 date = "2018-08-26T13:46:31-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-082717.md
+++ b/content/blog/last-week-in-pony-082717.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - August 27, 2017"
 date = "2017-08-27T07:11:42-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-090218.md
+++ b/content/blog/last-week-in-pony-090218.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - September 2, 2018"
 date = "2018-09-03T00:05:48-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-090317.md
+++ b/content/blog/last-week-in-pony-090317.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - September 3, 2017"
 date = "2017-09-03T07:11:00-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-090918.md
+++ b/content/blog/last-week-in-pony-090918.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - September 9, 2018"
 date = "2018-09-09T22:25:25-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-091017.md
+++ b/content/blog/last-week-in-pony-091017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - September 10, 2017"
 date = "2017-09-10T07:11:51-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-091618.md
+++ b/content/blog/last-week-in-pony-091618.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - September 16, 2018"
 date = "2018-09-16T20:04:38-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-091717.md
+++ b/content/blog/last-week-in-pony-091717.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - September 17, 2017"
 date = "2017-09-17T07:11:57-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-092318.md
+++ b/content/blog/last-week-in-pony-092318.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - September 23, 2018"
 date = "2018-09-24T09:08:08-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-092417.md
+++ b/content/blog/last-week-in-pony-092417.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - September 24, 2017"
 date = "2017-09-24T10:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-100317.md
+++ b/content/blog/last-week-in-pony-100317.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - October 03, 2017"
 date = "2017-10-03T20:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-100718.md
+++ b/content/blog/last-week-in-pony-100718.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - October 7, 2018"
 date = "2018-10-07T22:40:34-04:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-100817.md
+++ b/content/blog/last-week-in-pony-100817.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - October 08, 2017"
 date = "2017-10-08T21:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-101418.md
+++ b/content/blog/last-week-in-pony-101418.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - October 14, 2018"
 date = "2018-10-14T18:25:00-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-10152017.md
+++ b/content/blog/last-week-in-pony-10152017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - October 15, 2017"
 date = "2017-10-15T08:45:59-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-10222017.md
+++ b/content/blog/last-week-in-pony-10222017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - October 22, 2017"
 date = "2017-10-22T10:00:00+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-102818.md
+++ b/content/blog/last-week-in-pony-102818.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - October 28, 2018"
 date = "2018-10-28T20:56:14-04:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-10292017.md
+++ b/content/blog/last-week-in-pony-10292017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - October 29, 2017"
 date = "2017-10-29T10:53:32+02:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-110418.md
+++ b/content/blog/last-week-in-pony-110418.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - November 4, 2018"
 date = "2018-11-04T11:55:56-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-11052017.md
+++ b/content/blog/last-week-in-pony-11052017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - November 5, 2017"
 date = "2017-11-05T10:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-111118.md
+++ b/content/blog/last-week-in-pony-111118.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - November 11, 2018"
 date = "2018-11-11T18:07:23-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-11122017.md
+++ b/content/blog/last-week-in-pony-11122017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - November 12, 2017"
 date = "2017-11-12T17:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-111818.md
+++ b/content/blog/last-week-in-pony-111818.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - November 18, 2018"
 date = "2018-11-18T11:40:22-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-11192017.md
+++ b/content/blog/last-week-in-pony-11192017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - November 19, 2017"
 date = "2017-11-19T09:33:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-112518.md
+++ b/content/blog/last-week-in-pony-112518.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - November 25, 2018"
 date = "2018-11-25T20:05:32-05:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-11262017.md
+++ b/content/blog/last-week-in-pony-11262017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - November 26, 2017"
 date = "2017-11-26T09:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-120218.md
+++ b/content/blog/last-week-in-pony-120218.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - December 2, 2018"
 date = "2018-12-02T18:40:38-05:00"
 +++
 
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-12032017.md
+++ b/content/blog/last-week-in-pony-12032017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - December 03, 2017"
 date = "2017-12-03T09:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-120918.md
+++ b/content/blog/last-week-in-pony-120918.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - December 9, 2018"
 date = "2018-12-09T09:41:27-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 

--- a/content/blog/last-week-in-pony-12102017.md
+++ b/content/blog/last-week-in-pony-12102017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - December 10, 2017"
 date = "2017-12-10T09:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-121618.md
+++ b/content/blog/last-week-in-pony-121618.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - December 16, 2018"
 date = "2018-12-16T10:58:30-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-12172017.md
+++ b/content/blog/last-week-in-pony-12172017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - December 17, 2017"
 date = "2017-12-17T09:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-122318.md
+++ b/content/blog/last-week-in-pony-122318.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - December 23, 2018"
 date = "2018-12-23T11:22:57-05:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user).
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->

--- a/content/blog/last-week-in-pony-12242017.md
+++ b/content/blog/last-week-in-pony-12242017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Week in Pony - December 24, 2017"
 date = "2017-12-24T00:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -27,7 +27,7 @@ The [Release Blog Post](https://www.ponylang.io/blog/2017/12/0.21.0-released/) c
 
 - [Ponycheck](https://github.com/mfelsche/ponycheck) [0.2.0](https://github.com/mfelsche/ponycheck/releases/tag/0.2.0) has been released. Ponycheck is a library for property based testing for Pony. With this release Ponycheck supports compositional shrinking. If you ask yourself what the heck that means (like me), check out the [Release Notes](https://github.com/mfelsche/ponycheck/releases/tag/0.2.0)
 
-- Another Week, another Pony Development Sync Call. Those calls are public and if you'd like to join and bring up a burning topic, just join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you on board to discuss your issues and/or ideas. Here is the [Recorded Audio for last weeks Call](https://pony.groups.io/g/dev/files/Pony%20Sync/2017_12_20).
+- Another Week, another Pony Development Sync Call. Those calls are public and if you'd like to join and bring up a burning topic, just We'd love to have you on board to discuss your issues and/or ideas. Here is the [Recorded Audio for last weeks Call](https://pony.groups.io/g/dev/files/Pony%20Sync/2017_12_20).
 
 
 ## RFCs

--- a/content/blog/last-week-in-pony-12312017.md
+++ b/content/blog/last-week-in-pony-12312017.md
@@ -8,7 +8,7 @@ categories = [
 title = "Last Last Week in Pony for 2017 - December 31, 2017"
 date = "2017-12-31T15:00:00+01:00"
 +++
-_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [users' mailing list](https://pony.groups.io/g/user). 
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](https://ponylang.io), our Twitter account [@ponylang](https://twitter.com/ponylang), or our [Zulip community](https://ponylang.zulipchat.com).
 
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
@@ -30,7 +30,7 @@ This release comes with improved stability and memory consumption of the runtime
 
 ## Items of note
 
-- Due to the holidays there has been no Pony Development Sync this week. The next one is scheduled for Wednesday, January 3, 2017 at 03:30 PM (GMT-05:00) America/New York via zoom. Join the [Dev Mailing List](https://pony.groups.io/g/dev) to get all the details. We'd love to have you there.
+- Due to the holidays there has been no Pony Development Sync this week. The next one is scheduled for Wednesday, January 3, 2017 at 03:30 PM (GMT-05:00) America/New York via zoom. We'd love to have you there.
 
 ## New RFCs
 

--- a/content/blog/state-of-the-stable-2016.md
+++ b/content/blog/state-of-the-stable-2016.md
@@ -13,17 +13,15 @@ We asked far more questions this year than we plan to ask in the future. In larg
 
 ## Highlights
 
-Almost 49% of respondents said they were planning on doing web development with Pony. We didn't see this coming at all. It was quite a surprise. That simple "you could write an HTTP server" in Pony looks like it needs to be replaced by the real thing. If you are one of the people who answered that they are looking to do web development with Pony, we'd love to hear more from you on the [Pony+dev mailing list](https://groups.io/g/pony+dev) about what you need to make Pony a viable web development platform for you.
+Almost 49% of respondents said they were planning on doing web development with Pony. We didn't see this coming at all. It was quite a surprise. That simple "you could write an HTTP server" in Pony looks like it needs to be replaced by the real thing.
 
 Respondents tend to have a lot of programming experience. Over 70% have more than 10 years of experience while less than 5% have less than 5 years experience. Our first reaction was "that makes sense, people with more experience are more likely to have experienced the pain that other concurrency models can create". However, we also started to wonder how much of that is selection bias. Is there a way that we can market Pony that would appeal to people with less experience? They core Pony team has a lot of experience and we might be unintentionally appealing to people like us. It's something we are looking at.
 
-There's a lot of dynamic languages showing up in the languages that people are using. How many users are using just dynamic languages? Turns out it’s only a couple of respondents. However, there are a few others who appear to be primarily using dynamic languages with a static one thrown in. In general, you appear to be a pretty polyglot group. There's no "one language" that Pony is drawing a lot of interest from, it's pretty spread out. To address that, we are looking at doing "Pony for Erlangers", "Pony for C++ers", "Pony for Rubyists" etc intro docs. If you'd be interesting writing any such document, please stop by the [Pony+dev mailing list](https://groups.io/g/pony+dev) and let us know.
+There's a lot of dynamic languages showing up in the languages that people are using. How many users are using just dynamic languages? Turns out it’s only a couple of respondents. However, there are a few others who appear to be primarily using dynamic languages with a static one thrown in. In general, you appear to be a pretty polyglot group. There's no "one language" that Pony is drawing a lot of interest from, it's pretty spread out. To address that, we are looking at doing "Pony for Erlangers", "Pony for C++ers", "Pony for Rubyists" etc intro docs.
 
 The vast majority of respondents (over 70%) are just checking out the language. Hopefully we can pull some of those people in as full time users. Based on some of the free form feedback, we know that there are areas of the documentation that we need to address in order to do that. That 18% of you said that you are using Pony for serious hobby projects was a really big boost to our morale. It means a lot to know people are doing "real work" with our creation. One side note from Sean, it's obvious that his coworkers didn't fill out the survey otherwise there'd be several more "I use it at work" entries. Consider yourself shamed if you work with him.
 
 Documentation... well, thanks folks. You said nicer things about the Pony documentation than we do. That said, a lot of the free form feedback was focused on documentation. In particular, documentation around reference capabilities. We have work underway to address documentation and it will be a point of emphasis going forward. Hopefully by the end of the year, we'll have some awesome, beginner friendly documentation that will rival the languages that some of you brought up as favorites (and to the people who brought up Rust and Elm compiler error friendliness as goals to shoot for: we heard you, it’s something that was already on the roadmap, but oh yeah, we heard you).
-
-To the over 50% of respondents who said they wish there was a Pony User Group in your area, how would you feel about joining a virtual meetup group that meets over something like [Crowdcast](https://www.crowdcast.io/) or a combo of something like [Zoom](https://zoom.us) and [Slack](https://slack.com)? [We'd love to hear from you on that](https://groups.io/g/pony+user/message/145).
 
 ## Our message to you
 
@@ -33,7 +31,7 @@ Thank you for taking the time to give us feedback. It means a ton. This isn't me
 * Better packaging/easier installation
 * Distributed Pony
 
-We'd love your help. If you are interested in assisting, please join the [Pony+Dev mailing list](https://groups.io/g/pony+dev) and [check out some of the ways that anyone can contribute]({{< ref "contribute/index.md" >}}).
+We'd love your help. If you are interested in assisting, please join the [contribute to Pony stream in our Zulip community](https://ponylang.zulipchat.com/#narrow/stream/192795-contribute-to.20Pony) and [check out some of the ways that anyone can contribute]({{< ref "contribute/index.md" >}}).
 
 See y'all next year,
 The Pony core team

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -11,10 +11,7 @@ We are committed to providing a friendly, safe and welcoming environment for all
 The most important community resources for those who are new to Pony are:
 
 * Pony [community Zulip](https://ponylang.zulipchat.com)
-* The [Users Mailing List](https://pony.groups.io/g/user) for discussion of all things Pony that don't involve the development of Pony itself
 * The [frequently asked questions]({{< relref "faq/index.md">}}) section of this website.
-
-If you are looking for help with Pony and can't get a response in Zulip, we advise that you send an email to the Users Mailing List. 
 
 ## News
 
@@ -41,28 +38,26 @@ but, that can come later.
 
 If you are interested in having a real time conversation about Pony, check out the Pony [community Zulip](https://ponylang.zulipchat.com).
 
-## Mailing Lists
+## Zulip Community
 
-We host all our mailing lists with [groups.io](https://groups.io). You'll need a [groups.io account](https://groups.io/register) to sign up for any of our mailing lists. By joining any of the Pony mailing lists, you will also be automatically added to [an announce only broadcast list](https://pony.groups.io/g/pony).
+Most Pony community interactions happen in our [Zulip community](https://ponylang.zulipchat.com). Zulip is kind of like Slack but, better. Well we think it's better anyway. One of the big differences how Zulip organizes conversations. You can learn more about that in their [Steams and topics documentation](https://zulipchat.com/help/about-streams-and-topics).
 
-If you are a Pony user looking for assistance or to  discuss writing Pony code, you'll want to join the [Users' mailing list](https://pony.groups.io/g/user).
+Once you join our Zulip, there are a number of streams that you'll be subscribed to by default. Some key streams you might be interested in are:
 
-If you are looking to contribute to Pony, you'll want to join the [Developers' mailing list](https://pony.groups.io/g/dev).
+If you are a Pony user looking for assistance or to  discuss writing Pony code, you'll want to join the [beginner help steam in our Zulip community](https://ponylang.zulipchat.com/#narrow/stream/189985-beginner-help).
 
-If you are interested in finding out when our Virtual Users' Group is meeting or when new videos are posted, you should join the [Virtual Users' Group mailing list](https://pony.groups.io/g/vug).
+If you are looking to contribute to Pony, you'll want to join the [contrinute to Pony stream in our Zulip community](https://ponylang.zulipchat.com/#narrow/stream/192795-contribute-to.20Pony).
+
+If you are interested in finding out when our Virtual Users' Group is meeting or when new videos are posted, you should join [announce stream in our Zulip community](https://ponylang.zulipchat.com/#narrow/stream/189932-announce/topic/VUG).
 
 ## Users' Groups
 
-We currently know of 3 User Groups. We also have a [Virtual Users' Group](https://pony.groups.io/g/vug) which didn't meet in quite some time now. In general, it meets about once a month via [Zoom](https://zoom.us). If you would be interested, join and drop us a line, we would be happy to revive that tradition.
+We currently know of 1 User Group. We also have a Virtual Users' Group which didn't meet in quite some time now. In general, it meets about once a month via [Zoom](https://zoom.us). If you would be interested, join and drop us a line, we would be happy to revive that tradition.
 [Videos](https://vimeo.com/search/sort:latest?q=pony-vug) of past presentations are available.
 
 If you'd like to attend an in-person meetup, sign up for the mailing list or join the meetup group to be informed the next time a meeting is occuring:
 
-* [London Users' Group](https://pony.groups.io/g/london)
-* [New York City Users' Group](https://pony.groups.io/g/nyc)
 * [Berlin Users' Group](https://www.meetup.com/de-DE/Berlin-Ponylang-Meetup/)
-
-If you are interested in setting up a users' group in your area and would like to host the mailing list on groups.io, drop us a line and we'll get you set up.
 
 ## Community Survey
 

--- a/content/contribute/index.md
+++ b/content/contribute/index.md
@@ -2,7 +2,7 @@
 title = "Contribute"
 +++
 
-Interested in helping develop Pony? Awesome. We could use the help. Here's a list of projects that are currently underway that you can assist with. If none of them interest you, drop a note to the [pony+dev mailing list](https://pony.groups.io/g/dev) and we should be able to find something that suits your interests.
+Interested in helping develop Pony? Awesome. We could use the help. Here's a list of projects that are currently underway that you can assist with. If none of them interest you, drop a note to the [Zulip community](https://ponylang.zulipchat.com) and we should be able to find something that suits your interests.
 
 Not sure where to start?
 

--- a/content/learn/index.md
+++ b/content/learn/index.md
@@ -5,10 +5,7 @@ Ready to learn Pony? Awesome.
 
 ## Getting help {#getting-help}
 
-If you run into trouble while you are learning Pony, don't worry, we've got you covered. You have a couple different options on how you can get help from the Pony community. If you are looking for an answer "right now", we suggest you give our Zulip community a try. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or Zulip isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
-
-* [Mailing list](https://pony.groups.io/g/user).
-* [Zulip](https://ponylang.zulipchat.com)
+If you run into trouble while you are learning Pony, don't worry, we've got you covered. If you are looking for an answer "right now", we suggest you give our [Zulip community](https://ponylang.zulipchat.com/#narrow/stream/189985-beginner-help) a try. Whatever your question is, it isn't dumb, and we won't get annoyed.
 
 Many folks encounter the same issues or have the same questions, be sure to give the [frequently asked questions]({{< relref "faq/index.md">}}) section of this website a read.
 

--- a/content/sponsors/index.md
+++ b/content/sponsors/index.md
@@ -39,10 +39,6 @@ The following companies kindly donate resources to Pony. We are incredibly grate
 
 [CircleCI](https://circleci.com/) runs our continuous integration tests on Linux. It lets us test our code on manifold configurations and architectures. They support several open source projects. Amazing solution.
 
-### Groups.io
-
-[Groups.io](https://groups.io/) hosts our mailing lists. They have some additional "forum-like" features including calendars and file hosting. We take advantage of both for hosting the recordings of our weekly development sync. If you are looking for a replacement for Google Groups, check them out.
-
 ### JFrog
 
 [JFrog](https://www.jfrog.com/) hosts our release artifacts on [Bintray](https://bintray.com/). They are some of the nicest people we've ever dealt with. We initially set up our bintray in a way that was using way too much space. They worked with us to solve the problem **AND** set us up with a free [Artifactory](https://www.jfrog.com/artifactory/) account as well.


### PR DESCRIPTION
We are shutting down the mailing lists as they don't get much usage.
There's still a few references on the site. Primarily, links to sync
audio recordings that haven't been moved to a new home. Additionally,
links to specific mailing list messages have been left because, those
aren't moving. We are however, making the mailing lists read-only.