### PR TITLE
Update "Sponsors" page

### DIFF
--- a/content/sponsors/index.md
+++ b/content/sponsors/index.md
@@ -39,6 +39,10 @@ The following companies kindly donate resources to Pony. We are incredibly grate
 
 [CircleCI](https://circleci.com/) runs our continuous integration tests on Linux. It lets us test our code on manifold configurations and architectures. They support several open source projects. Amazing solution.
 
+### Cirrus CI
+
+[Cirrus CI](https://cirrus-ci.org/) provide us with free services to run our FreeBSD and MacOS CI jobs, like they do to all open source projects. Simply brilliant.
+
 ### JFrog
 
 [JFrog](https://www.jfrog.com/) hosts our release artifacts on [Bintray](https://bintray.com/). They are some of the nicest people we've ever dealt with. We initially set up our bintray in a way that was using way too much space. They worked with us to solve the problem **AND** set us up with a free [Artifactory](https://www.jfrog.com/artifactory/) account as well.
@@ -49,4 +53,8 @@ The following companies kindly donate resources to Pony. We are incredibly grate
 
 ### Travis CI
 
-[Travis CI](https://travis-ci.org/) runs our continuous integration tests on both Linux and MacOS. They support a ton of open source projects. Great project.
+[Travis CI](https://travis-ci.org/) runs our continuous integration tests on Linux and our release deployments. They support a ton of open source projects. Great project.
+
+### Zulip
+
+[Zulip](https://zulipchat.com/) powers and hosts [our team chat service](https://ponylang.zulipchat.com/), thanks to their [open-source hosting plan](https://zulipchat.com/for/open-source/). We're very happy with it!


### PR DESCRIPTION
Add Cirrus CI and Zulip, and update the Travis CI section to include only
Linux tests and deployment jobs.

Closes #395, closes #410