### PR TITLE
Correct typos in community section

### DIFF
--- a/content/community/index.md
+++ b/content/community/index.md
@@ -40,11 +40,11 @@ If you are interested in having a real time conversation about Pony, check out t
 
 ## Zulip Community
 
-Most Pony community interactions happen in our [Zulip community](https://ponylang.zulipchat.com). Zulip is kind of like Slack but, better. Well we think it's better anyway. One of the big differences how Zulip organizes conversations. You can learn more about that in their [Steams and topics documentation](https://zulipchat.com/help/about-streams-and-topics).
+Most Pony community interactions happen in our [Zulip community](https://ponylang.zulipchat.com). Zulip is kind of like Slack but, better. Well we think it's better anyway. One of the big differences how Zulip organizes conversations. You can learn more about that in their [Streams and topics documentation](https://zulipchat.com/help/about-streams-and-topics).
 
 Once you join our Zulip, there are a number of streams that you'll be subscribed to by default. Some key streams you might be interested in are:
 
-If you are a Pony user looking for assistance or to  discuss writing Pony code, you'll want to join the [beginner help steam in our Zulip community](https://ponylang.zulipchat.com/#narrow/stream/189985-beginner-help).
+If you are a Pony user looking for assistance or to  discuss writing Pony code, you'll want to join the [beginner help stream in our Zulip community](https://ponylang.zulipchat.com/#narrow/stream/189985-beginner-help).
 
 If you are looking to contribute to Pony, you'll want to join the [contribute to Pony stream in our Zulip community](https://ponylang.zulipchat.com/#narrow/stream/192795-contribute-to.20Pony).
 


### PR DESCRIPTION
This corrects the two places in the community section where the link text
referred to Zulip streams incorrectly as "steams".