### PR TITLE
update brew install llvm command

### DIFF
--- a/content/reference/pony-lldb-cheatsheet.md
+++ b/content/reference/pony-lldb-cheatsheet.md
@@ -7,7 +7,7 @@ title = "Pony LLDB Cheatsheet"
 ### macOS Setup
 
 ```bash
-% brew install llvm@3.9
+% brew install llvm
 % sudo /usr/sbin/DevToolsSecurity --enable
 ```
 


### PR DESCRIPTION
`brew` no longer has an `llvm@3.9` version available.  The latest version works fine for me:

```bash
brew search llvm 
==> Formulae
llvm ✔         llvm@11        llvm@7         llvm@8         llvm@9         wllvm
```

tested with `scratch.pony`:

```pony
actor Main
  new create(env: Env) =>
    let target = "world"
    let buf = recover String end

    buf.append("hello ")
    buf.append(target)

    env.out.print(consume buf)
```

I'm able to debug/breakpoint/etc with `lldb`:

```bash
ponyc --debug && lldb ./scratch                                              
Building builtin -> /Users/tednaleid/.local/share/ponyup/ponyc-release-0.43.0-x86_64-darwin/packages/builtin
Building . -> /Users/tednaleid/Dropbox/workspace/pony/scratch
Generating
 Reachability
 Selector painting
 Data prototypes
 Data types
 Function prototypes
 Functions
 Descriptors
Writing ./scratch.o
Linking ./scratch
(lldb) target create "./scratch"
Current executable set to '/Users/tednaleid/Dropbox/workspace/pony/scratch/scratch' (x86_64).
(lldb) breakpoint set --file scratch.pony --line 8
Breakpoint 1: where = scratch`Main_tag_create_oo + 179 at scratch.pony:9:18, address = 0x0000000100001523
(lldb) run
Process 4040 launched: '/Users/tednaleid/Dropbox/workspace/pony/scratch/scratch' (x86_64)
Process 4040 stopped
* thread #5, stop reason = breakpoint 1.1
    frame #0: 0x0000000100001523 scratch`Main_tag_create_oo(this=0x0000000108ffe000, env=0x0000000108ffdc00) at scratch.pony:9:18
   6        buf.append("hello ")
   7        buf.append(target)
   8   
-> 9        env.out.print(consume buf)
Target 0: (scratch) stopped.
(lldb) p (char *)(buf->_ptr)
(char *) $0 = 0x0000000108fd3380 "hello world"
```