### PR TITLE
Remove CirrusCI from Sponsors

### DIFF
--- a/content/sponsors/index.md
+++ b/content/sponsors/index.md
@@ -31,10 +31,6 @@ The following companies kindly donate resources to Pony. We are incredibly grate
 
 [1Password](https://1password.com) hosts our shared secrets for free as part of their [open source support](https://github.com/1Password/1password-teams-open-source). It solves quite a few problems for us.
 
-### Cirrus CI
-
-[Cirrus CI](https://cirrus-ci.org/) provide us with free services to run our FreeBSD and MacOS CI jobs, like they do to all open source projects. Simply brilliant.
-
 ### Cloudsmith
 
 [Cloudsmith](https://cloudsmith.io/) is providing free hosting for our nightly builds. That's incredibly awesome and they are great folks.


### PR DESCRIPTION
We are moving away from CirrusCI as they no longer have unlimited free CI and we quite rapidly overshoot their monthly limits.