### PR TITLE
Update "anonymous" gist links

### DIFF
--- a/content/blog/last-week-in-pony-03042018.md
+++ b/content/blog/last-week-in-pony-03042018.md
@@ -36,7 +36,7 @@ No matter what, share it! There is no good or bad or simple or advanced.
 
 As I just invented this crazy section, I am taking the freedom to post the first link:
 
-#### [Last Weeks Playground](http://playground.ponylang.io/?gist=0e31414bb350a315509df5c08850618f)
+#### [Last Weeks Playground](https://playground.ponylang.io/?gist=b0479f78f80ff23469b2d74038ffec33)
 
 This one is about generic primitives.
 

--- a/content/blog/last-week-in-pony-03112018.md
+++ b/content/blog/last-week-in-pony-03112018.md
@@ -30,7 +30,7 @@ Alex notes:
 >
 > This allows types to be easily declared as "opposites" of each other
 
-[Trait Subtyping](https://playground.ponylang.io/?gist=dc16ebcb1b75682bd385b7b9c078fb46)
+[Trait Subtyping](https://playground.ponylang.io/?gist=13c4ad2c9752cd90d5ecc0860469f4d7)
 
 ## RFCs
 

--- a/content/blog/last-week-in-pony-03182018.md
+++ b/content/blog/last-week-in-pony-03182018.md
@@ -23,7 +23,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 This week I am going to present you the `with` expression in Pony. *The `with` expression???*, you ask?
 Yes, this undocumented gem that definitely needs more coverage in the tutorial.
 
-Here is the playground link: [http://playground.ponylang.io/?gist=c8d70a175b7fde58d42f021e88595a89](http://playground.ponylang.io/?gist=c8d70a175b7fde58d42f021e88595a89)
+Here is the playground link: [https://playground.ponylang.io/?gist=3e3b043fa4ac8f6edea4f232776a3a52](https://playground.ponylang.io/?gist=3e3b043fa4ac8f6edea4f232776a3a52)
 
 In case you want to submit one (which I highly recommend), just add it as a comment to the current [Last Week in Pony Issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony) and let people vote with `+1` reactions. The one with the most votes is presented (Or i just present them all. Depends on my Sunday evening mood).
 

--- a/content/blog/last-week-in-pony-073017.md
+++ b/content/blog/last-week-in-pony-073017.md
@@ -23,7 +23,7 @@ At this time this "Last Week in Pony" was published, we were in [the process of 
 
 - Matthias Wahl announced [Ponycheck](https://github.com/mfelsche/ponycheck)- a property based testing tool for Pony. For more details, check out the [announcement on the mailing list](https://pony.groups.io/g/user/message/1263).
 - Stewart Gebbie announced [Pony Watcher](https://github.com/sgebbie/pony-watcher). Some scripts he uses to speed up his development cycle. Learn more from his [mailing list announcement](https://pony.groups.io/g/user/message/1264).
-- The [Pony Playground](https://playground.ponylang.io/) now compiles your programs in debug mode. This change makes `Debug.out("foo")` now result in output. [Enjoy](https://playground.ponylang.io/?gist=8835236a430b10147eb640825ba73b5f)!
+- The [Pony Playground](https://playground.ponylang.io/) now compiles your programs in debug mode. This change makes `Debug.out("foo")` now result in output. [Enjoy](https://playground.ponylang.io/?gist=66aab8cfb7fb9be14b7d2c2b9b91b617)!
 - We're looking for help putting together documentation on how to cross-compile Pony programs. If you have experience and can help, [please respond on the mailing list](https://pony.groups.io/g/user/message/1254).
 - The Pony Virtual Users' Group needs you! [Get involved today!](https://pony.groups.io/g/user/message/1280)
 - Audio from the [July 26, 2017, Pony development sync](https://sync-recordings.ponylang.io/r/2017_07_26.m4a) is available for your listening pleasure.

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -91,7 +91,7 @@ actor Main
     foo()
 ```
 
-Check out [the example program in the Pony Playground](https://playground.ponylang.io/?gist=26fce9986dd82a58f8bcd5197e22121f).
+Check out [the example program in the Pony Playground](https://playground.ponylang.io/?gist=0045ecb177ab3adf06b5477fc53bdfb7).
 
 For more information see the [Sugar](https://tutorial.ponylang.io/expressions/sugar.html) section of the the tutorial.
 


### PR DESCRIPTION
As noted in issue #909, some of our playground links that appear in Last Week in Pony issues and other website content, contain gists that aren't under our ponylang-gists account.

Anonymous gist links are no longer allowed and there is no guarantee that they won't stop working in the future. This commit future proofs us.

Closes #909