### PR TITLE
Remove broken curry-on.org links

### DIFF
--- a/docs/blog/posts/last-week-in-pony-043017.md
+++ b/docs/blog/posts/last-week-in-pony-043017.md
@@ -27,7 +27,7 @@ It was a bit of a quiet week in terms of public activity but there's plenty brew
 
 ## News
 
-- Sylvan Clebsch, creator of Pony, will be giving a [talk](http://www.curry-on.org/2017/sessions/pony-714-days-later.html) at Curry On in Barcelona about how Pony has grown over the last two years. Once again, Curry On is looking like an [amazing conference](http://www.curry-on.org/2017/). If you get a chance, you should attend.
+- Sylvan Clebsch, creator of Pony, will be giving a talk at Curry On in Barcelona about how Pony has grown over the last two years. Once again, Curry On is looking like an amazing conference If you get a chance, you should attend.
 
 ## RFCs
 

--- a/docs/blog/posts/last-week-in-pony-062517.md
+++ b/docs/blog/posts/last-week-in-pony-062517.md
@@ -16,7 +16,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 ## Items of note
 
-- Video of Sylvan's [Curry On](http://www.curry-on.org/2017/) talk ["Pony: 714 Days Later"](https://www.youtube.com/watch?v=HGDSnOZaU7Y) is now available. The talk is intended to be a followup to [his first Curry On talk about Pony](https://www.youtube.com/watch?v=KvLjy8w1G_U). "Pony: 714 Days Later" stands on its own. However, it is interesting to watch both and get a feel for what has changed with Pony over the two intervening years.
+- Video of Sylvan's Curry On talk ["Pony: 714 Days Later"](https://www.youtube.com/watch?v=HGDSnOZaU7Y) is now available. The talk is intended to be a followup to [his first Curry On talk about Pony](https://www.youtube.com/watch?v=KvLjy8w1G_U). "Pony: 714 Days Later" stands on its own. However, it is interesting to watch both and get a feel for what has changed with Pony over the two intervening years.
 
 - A first version of [RFC #38: "CLI Syntax"](https://github.com/ponylang/rfcs/blob/main/text/0038-cli-format.md) has been [merged to main](https://github.com/ponylang/ponyc/pull/1897). This is the first step towards deprecating the `Options` package for command line argument parsing.
 


### PR DESCRIPTION
It looks like the domain is finally kaput after the conference stopped happening.