### PR TITLE
Allow validating the site on pull requests from forks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,20 +32,3 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Check spelling
         uses: rojopolis/spellcheck-github-actions@e0dcc87bedf34ff10d6be443753f1c770bacbaa2
-
-  validate-site:
-    name: mkdocs build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4.1.1
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-        env:
-          INSIDERS_PAT: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
-      - name: Build site
-        run: mkdocs build
-        env:
-          # turn off external url checking as it takes a long time and we
-          # do that on a schedule
-          VALIDATE_EXTERNAL_URLS: false

--- a/.github/workflows/validate-site-on-pr.yml
+++ b/.github/workflows/validate-site-on-pr.yml
@@ -1,0 +1,28 @@
+name: PR
+
+on: pull_request_target
+
+concurrency:
+  group: pr-target-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  validate-site:
+    name: mkdocs build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4.1.1
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        env:
+          INSIDERS_PAT: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
+      - name: Build site
+        run: mkdocs build
+        env:
+          # turn off external url checking as it takes a long time and we
+          # do that on a schedule
+          VALIDATE_EXTERNAL_URLS: false


### PR DESCRIPTION
Run a pull_request_target version that can have access to the insiders build secret.