### PR TITLE
Changed linked ssl library to ponylang/ssl

### DIFF
--- a/docs/faq/ecosystem.md
+++ b/docs/faq/ecosystem.md
@@ -6,4 +6,4 @@ That would be yes and no. Package manager means different things to different pe
 
 ## Is there SSL support? {:id="ssl"}
 
-Yes! There used to be SSL support in the Pony standard library, but it's been moved out [into its own library](https://github.com/ponylang/net-ssl).
+Yes! There used to be SSL support in the Pony standard library, but it's been moved out [into its own library](https://github.com/ponylang/ssl).


### PR DESCRIPTION
Modified the link to the ssl library in the FAQ from ponylang/net-ssl to ponylang/ssl