### PR TITLE
Add "Install" nav link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ theme:
 
 nav:
   - Home: "index.md"
+  - Install: "https://github.com/ponylang/ponyc/blob/main/INSTALL.md"
   - Discover:
       - What is Pony?: "discover/index.md"
       - What makes Pony different?: "discover/what-makes-pony-different.md"


### PR DESCRIPTION
This patch is probably incorrect.

The index page (https://www.ponylang.io/) has too many bullet points that could be organized. I was confused and couldn't find the download link, so I made this patch. Hopefully you get the idea.