### PR TITLE
Fix Matthias spelling in LWIP 2024-06-30 post

### DIFF
--- a/docs/blog/posts/last-week-in-pony-063024.md
+++ b/docs/blog/posts/last-week-in-pony-063024.md
@@ -8,7 +8,7 @@ title: "Last Week in Pony - June 30, 2024"
 date: 2024-06-30T07:00:06-04:00
 ---
 
-The big news from this past week is that Mathias has released "the first" version of Pony Language Server.
+The big news from this past week is that Matthias has released "the first" version of Pony Language Server.
 
 <!-- more -->
 


### PR DESCRIPTION
The contributor's name is Matthias Wahl (double-t), per his GitHub identity. This post had it as "Mathias" (single-t). Companion to #1313, which fixed the same typo in `embed-you-a-ponyc-for-great-good.md`.