### PR TITLE
Fix stale and copy-leftover content in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 Hi there! Thanks for your interest in contributing to the Pony website.
 
-Please note, that by submitting any content to the Pony Tutorial book you are agreeing that it can be licensed under our [license](LICENSE.md). Furthermore, you are testifying that you own the copyright to the submitted content and indemnify the Pony developers from any copyright claim that might result from your not being the authorized copyright holder.
+Please note, that by submitting any content to the Pony website you are agreeing that it can be licensed under our [license](LICENSE.md). Furthermore, you are testifying that you own the copyright to the submitted content and indemnify the Pony developers from any copyright claim that might result from your not being the authorized copyright holder.
 
-## Hugo
+## mkdocs
 
-The Pony website is generated using [`mkdocs`]: a static website generator. If you are making larger changes to the site, you will need to install `mkdocs` locally to verify your changes are working.
+The Pony website is generated using [mkdocs], a static website generator. If you are making larger changes to the site, you will need to install `mkdocs` locally to verify your changes are working.
 
 ## Ponylang.io hosting
 
@@ -16,7 +16,7 @@ Ponylang.io is hosted using [Netlify].
 
 Any update to the `main` branch kicks off a build process on Netlify that will result in the website being updated. Previews of changes are available via our PR process.
 
-Netlify offers "deploy previews" that allow you to view the results of a PR before it goes live. Each PR will kick off the creation of a preview that can be view changes before merging. The Netlify preview is available as part of the PR as a "check".
+Netlify offers "deploy previews" that allow you to view the results of a PR before it goes live. Each PR will kick off the creation of a preview you can use to view changes before merging. The Netlify preview is available as part of the PR as a "check".
 
 To see the preview, on the PR page select `Show all checks` and then click `Details` next to `deploy/netlify - Deploy preview is ready!`
 
@@ -27,13 +27,13 @@ To do larger changes, you'll want to install mkdocs locally so you can test your
 For simpler tasks, once you have mkdocs installed, you should be able to:
 
 ```bash
-cd ponylang.github.io
+cd ponylang-website
 mkdocs serve
 ```
 
-Which will start up a local webserver that will serve the Ponylang website on `http://localhost:8080`.
+Which will start up a local webserver that will serve the Ponylang website on `http://localhost:8000`.
 
-Once you are happy with your changes, commit then and submit a PR. Before doing that, please read the following 'How to submit a pull request' section.
+Once you are happy with your changes, commit them and submit a PR. Before doing that, please read the following 'How to submit a pull request' section.
 
 ## How to submit a pull request
 
@@ -44,13 +44,13 @@ Once your content is done, please open a pull request against this repo with you
 * Changes to how the content falls into the overall site organization
 * Changes to make sure that new content works across a variety of devices
 
-Be sure to keep your PR to a single topic or logical change. If you are working on multiple changes, make sure they are each on their own branch and that before creating a new branch that you are on the main branch (others multiple changes might end up in your pull request). To repeat, each PR should be for a single logical change. We request that you create a good commit messages as laid out in ['How to Write a Git Commit Message'](http://chris.beams.io/posts/git-commit/).
+Be sure to keep your PR to a single topic or logical change. If you are working on multiple changes, make sure they are each on their own branch and that before creating a new branch that you are on the main branch (others multiple changes might end up in your pull request). To repeat, each PR should be for a single logical change. We request that you create good commit messages as laid out in ['How to Write a Git Commit Message'](http://chris.beams.io/posts/git-commit/).
 
-If your PR is for a single logical change (which is should be) but spans multiple commits, we'll quash them into a single commit when we merge. Please make sure your first comment is the message we should use as the final commit message.
+If your PR is for a single logical change (which it should be) but spans multiple commits, we'll squash them into a single commit when we merge. Please make sure your first comment is the message we should use as the final commit message.
 
 ## Relative vs Absolute links
 
 Favor relative links for any content on ponylang.io. Absolute links that point to `https://www.ponylang.io` don't play well with Netlify deploy previews. Absolute links will redirect you off the preview website and onto the live website. For this reason, relative links are preferred.
 
 [mkdocs]: https://www.mkdocs.org/
-[Netlify]: https://www.netlify.com/.
+[Netlify]: https://www.netlify.com/


### PR DESCRIPTION
`CONTRIBUTING.md` was copied from another ponylang repo and never fully updated to this one. None of this breaks the build, but all of it misleads contributors:

- "Pony Tutorial book" → "Pony website"
- `## Hugo` heading → `## mkdocs` (the body already described mkdocs; the site isn't built with Hugo)
- `cd ponylang.github.io` → `cd ponylang-website` (actual clone directory)
- local serve URL `:8080` → `:8000` (mkdocs default; no custom `dev_addr`)
- broken `[` + backtick mkdocs reference link on first mention → working `[mkdocs]` reference (it was rendering as literal text)
- typos/grammar: "quash" → "squash", "commit then" → "commit them", "a good commit messages" → "good commit messages", "(which is should be)" → "(which it should be)", "a preview that can be view changes" → "a preview you can use to view changes", and a stray trailing `.` on the `[Netlify]` link

Verified `CONTRIBUTING.md` passes the repo's super-linter markdownlint check.

Out of scope, tracked separately: `README.md` still titled `ponylang.github.io`, and the local-install step doesn't mention `requirements.txt` (a bare `pip install mkdocs` misses the site's plugins).