### PR TITLE
Note that --runtimebc is incompatible with DTrace builds

### DIFF
--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -81,6 +81,9 @@ Then compile programs with:
 ponyc --runtimebc
 ```
 
+!!! note
+    `--runtimebc` cannot be used with a compiler built for [DTrace/SystemTap probes](../../use/compiler/custom-ponyc-builds.md#dtrace-systemtap); ponyc rejects the combination with an error.
+
 ## Instrumentation
 
 The `use=` option enables various instrumentation features. It is only valid with `make configure`. Multiple options can be combined with commas:

--- a/docs/use/compiler/custom-ponyc-builds.md
+++ b/docs/use/compiler/custom-ponyc-builds.md
@@ -127,6 +127,9 @@ For the full list of probes with parameter types and descriptions, see [`src/com
 !!! warning "Static linking on FreeBSD"
     Statically linked programs (`ponyc --static`) build and run but do not expose their probes to DTrace. FreeBSD registers USDT probes through the runtime linker, which a static binary doesn't use; trace a dynamically linked build instead.
 
+!!! warning "Runtime bitcode is incompatible with DTrace"
+    A ponyc built with `use=dtrace` cannot compile programs with `--runtimebc`, and rejects the combination with an error. Probe generation operates on native object files, not LLVM bitcode, so the bitcode runtime carries no probes — a `--runtimebc` binary would have none. Use the default static runtime to trace your program.
+
 ## Runtime Statistics
 
 Runtime statistics tracking instruments the Pony runtime to report memory usage per actor and per scheduler thread. This is useful for understanding where memory is going in a running program.


### PR DESCRIPTION
A ponyc built with `use=dtrace` cannot compile programs with `--runtimebc`: the bitcode runtime carries no probes (DTrace's probe generation works on native object files, not LLVM bitcode), and ponyc rejects the combination with an error.

Documents this in two places:
- The **DTrace / SystemTap** section (`use/compiler/custom-ponyc-builds.md`) gets a warning admonition alongside the existing static-linking one.
- The **Runtime Bitcode** section (`contribute/compiler/building-ponyc-from-source.md`) gets a note cross-linking to it, so a reader arriving from either feature learns of the limit.

Companion to ponylang/ponyc#5414, which adds the compiler error. Design: ponylang/ponyc#2915