### PR TITLE
Document build options unsupported on OpenBSD

### DIFF
--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -112,6 +112,9 @@ The available options:
 
 For detailed usage of valgrind, sanitizers, DTrace, and systematic testing, see [Custom ponyc Builds](../../use/compiler/custom-ponyc-builds.md).
 
+!!! warning "Some options aren't available on OpenBSD"
+    `valgrind`, `address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`, `coverage`, and `dtrace` depend on a runtime, headers, or tooling that OpenBSD doesn't ship, so they can't be built there. `gmake configure` rejects them on OpenBSD with an explanatory error instead of failing partway through the build. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#unsupported-build-options) for the details.
+
 ## IDE Integration
 
 To generate a `compile_commands.json` for clangd and other LSP tools:

--- a/docs/use/compiler/custom-ponyc-builds.md
+++ b/docs/use/compiler/custom-ponyc-builds.md
@@ -61,6 +61,9 @@ Compile your program with the instrumented ponyc, then run it under Valgrind:
 valgrind ./my-program
 ```
 
+!!! warning "Not available on OpenBSD"
+    Valgrind has no OpenBSD port, so its development headers aren't available and `use=valgrind` can't be built there. `gmake configure use=valgrind` is rejected on OpenBSD with an error.
+
 ## Address Sanitizer
 
 [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) (ASan) detects memory errors at runtime: buffer overflows, use-after-free, double-free, and stack buffer overflows.
@@ -73,6 +76,9 @@ make build
 Compile your program with the instrumented ponyc and run it normally. ASan reports errors to stderr as they occur.
 
 Cannot be combined with `thread_sanitizer`.
+
+!!! warning "Not available on OpenBSD"
+    OpenBSD's base toolchain ships no AddressSanitizer runtime, so `use=address_sanitizer` can't be built there. `gmake configure use=address_sanitizer` is rejected on OpenBSD with an error.
 
 ## Thread Sanitizer
 
@@ -87,6 +93,9 @@ Compile your program with the instrumented ponyc and run it normally. TSan repor
 
 Cannot be combined with `address_sanitizer`.
 
+!!! warning "Not available on OpenBSD"
+    OpenBSD's base toolchain ships no ThreadSanitizer runtime, so `use=thread_sanitizer` can't be built there. `gmake configure use=thread_sanitizer` is rejected on OpenBSD with an error.
+
 ## Undefined Behavior Sanitizer
 
 [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) (UBSan) detects undefined behavior at runtime: signed integer overflow, null pointer dereference, misaligned memory access, and other categories.
@@ -99,6 +108,9 @@ make build
 Compile your program with the instrumented ponyc and run it normally. UBSan reports violations to stderr.
 
 Can be combined with `address_sanitizer` or `thread_sanitizer`.
+
+!!! warning "Not available on OpenBSD"
+    OpenBSD ships only the minimal UndefinedBehaviorSanitizer runtime, not the standalone runtime ponyc links against, so `use=undefined_behavior_sanitizer` can't be built there. `gmake configure use=undefined_behavior_sanitizer` is rejected on OpenBSD with an error.
 
 ## DTrace / SystemTap
 


### PR DESCRIPTION
Several `use=` build options can't be built on OpenBSD because the runtime, headers, or tooling they depend on isn't available there. ponyc now rejects them at `gmake configure` time (ponylang/ponyc#5429); these docs explain which and why.

- `custom-ponyc-builds.md` — a "Not available on OpenBSD" admonition on the Valgrind, Address Sanitizer, Thread Sanitizer, and Undefined Behavior Sanitizer sections.
- `building-ponyc-from-source.md` — a note after the `use=` options table covering valgrind, the three sanitizers, coverage, and dtrace, linking to ponyc's BUILD.md.

Verified on an OpenBSD 7.8 VM (base clang 19.1.7): no ASan/TSan runtime, only minimal (not standalone) UBSan, incomplete profiling runtime for coverage, and no Valgrind port.

Merge ordering: the `building-ponyc-from-source.md` note links to `BUILD.md#unsupported-build-options`, a heading added by ponylang/ponyc#5429. Land that PR before (or together with) this one so the anchor resolves.