### PR TITLE
Note the sanitizers as unsupported on DragonFly BSD

### DIFF
--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -112,8 +112,8 @@ The available options:
 
 For detailed usage of valgrind, sanitizers, DTrace, and systematic testing, see [Custom ponyc Builds](../../use/compiler/custom-ponyc-builds.md).
 
-!!! warning "Some options aren't available on OpenBSD"
-    `valgrind`, `address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`, `coverage`, and `dtrace` depend on a runtime, headers, or tooling that OpenBSD doesn't ship, so they can't be built there. `gmake configure` rejects them on OpenBSD with an explanatory error instead of failing partway through the build. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#unsupported-build-options) for the details.
+!!! warning "Some options aren't available on OpenBSD or DragonFly BSD"
+    On OpenBSD, `valgrind`, `address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`, `coverage`, and `dtrace` depend on a runtime, headers, or tooling that OpenBSD doesn't ship, so they can't be built there; `gmake configure` rejects them with an explanatory error instead of failing partway through the build. On DragonFly BSD, the three sanitizers (`address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`) can't be built because its `gcc13` toolchain ships no sanitizer runtime; `coverage` and `valgrind` do work there. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#unsupported-build-options) for the details.
 
 ## IDE Integration
 

--- a/docs/use/compiler/custom-ponyc-builds.md
+++ b/docs/use/compiler/custom-ponyc-builds.md
@@ -77,8 +77,8 @@ Compile your program with the instrumented ponyc and run it normally. ASan repor
 
 Cannot be combined with `thread_sanitizer`.
 
-!!! warning "Not available on OpenBSD"
-    OpenBSD's base toolchain ships no AddressSanitizer runtime, so `use=address_sanitizer` can't be built there. `gmake configure use=address_sanitizer` is rejected on OpenBSD with an error.
+!!! warning "Not available on OpenBSD or DragonFly BSD"
+    OpenBSD's base toolchain ships no AddressSanitizer runtime, and DragonFly BSD's `gcc13` toolchain doesn't build one either, so `use=address_sanitizer` can't be built on either. `gmake configure use=address_sanitizer` is rejected on OpenBSD with an error.
 
 ## Thread Sanitizer
 
@@ -93,8 +93,8 @@ Compile your program with the instrumented ponyc and run it normally. TSan repor
 
 Cannot be combined with `address_sanitizer`.
 
-!!! warning "Not available on OpenBSD"
-    OpenBSD's base toolchain ships no ThreadSanitizer runtime, so `use=thread_sanitizer` can't be built there. `gmake configure use=thread_sanitizer` is rejected on OpenBSD with an error.
+!!! warning "Not available on OpenBSD or DragonFly BSD"
+    OpenBSD's base toolchain ships no ThreadSanitizer runtime, and DragonFly BSD's `gcc13` toolchain doesn't build one either, so `use=thread_sanitizer` can't be built on either. `gmake configure use=thread_sanitizer` is rejected on OpenBSD with an error.
 
 ## Undefined Behavior Sanitizer
 
@@ -109,8 +109,8 @@ Compile your program with the instrumented ponyc and run it normally. UBSan repo
 
 Can be combined with `address_sanitizer` or `thread_sanitizer`.
 
-!!! warning "Not available on OpenBSD"
-    OpenBSD ships only the minimal UndefinedBehaviorSanitizer runtime, not the standalone runtime ponyc links against, so `use=undefined_behavior_sanitizer` can't be built there. `gmake configure use=undefined_behavior_sanitizer` is rejected on OpenBSD with an error.
+!!! warning "Not available on OpenBSD or DragonFly BSD"
+    OpenBSD ships only the minimal UndefinedBehaviorSanitizer runtime, not the standalone runtime ponyc links against; DragonFly BSD's `gcc13` toolchain doesn't build the UBSan runtime at all. Either way, `use=undefined_behavior_sanitizer` can't be built there. `gmake configure use=undefined_behavior_sanitizer` is rejected on OpenBSD with an error.
 
 ## DTrace / SystemTap
 


### PR DESCRIPTION
Adds DragonFly BSD to the existing "not available on OpenBSD" notes, scoped to the three sanitizers (`address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`).

DragonFly builds ponyc with the `gcc13` package, whose toolchain ships no sanitizer runtime — GCC's libsanitizer has no DragonFly target, so libasan/libtsan/libubsan are never built. Verified empirically on a DragonFly 6.4.2 VM with `gcc13-13.3.0`: all three `-fsanitize=` link probes fail with `cannot find -lasan/-ltsan/-lubsan`, and the runtimes exist nowhere on the system.

Unlike OpenBSD, `coverage` and `valgrind` *do* work on DragonFly (gcc's libgcov ships and gcov13 is present; the `valgrind-lts` port provides the headers ponyc needs and the binary runs), so they're deliberately left out of the DragonFly note.

The DragonFly configure-time rejection isn't implemented in ponyc yet — that's forthcoming work — so the note states DragonFly as a toolchain fact ("can't be built — `gcc13` ships no sanitizer runtime") and keeps the "rejected at configure time" wording OpenBSD-scoped. A later change updates that once the ponyc reject lands.

Part of phase 7 of ponylang/ponyc#4941 (embedded LLD; removing the legacy linker).