### PR TITLE
Update linker docs for --linker/--link-ldcmd removal

### DIFF
--- a/docs/faq/compiling.md
+++ b/docs/faq/compiling.md
@@ -34,58 +34,22 @@ Make sure you're running a `cmd.exe`/`powershell.exe` that does not include 32-b
 
 This error occurs when ponyc is compiled in a 32-bit Visual Studio Developer Command Prompt.
 
-## How can I supply custom linker parameters? {:id="custom-linker-parameters"}
+## How can I link my program to a C library? {:id="custom-linker-parameters"}
 
-So, you need to link your program to a custom library or otherwise pass a particular linker option? You can accomplish your goal using the  `ponyc` `--linker` option.
+Declare the library in your Pony source with a `use "lib:..."` statement, and ponyc links it for you. To link the library `Foo`:
 
-You'll need to know what your current linker is. To get it, compile a pony program and pass `--verbose 3`.
-
-### On Linux, MacOS or other Unix-like
-
-Then examine the output. You should see something like:
-
-```bash
-ld -execute -no_pie -dead_strip -arch x86_64 -macosx_version_min 10.8
-  -o ./timer ./timer.o -L"/usr/local/lib/pony/0.9.0-e64bff88c/bin/"
-  -L"/usr/local/lib/pony/0.9.0-e64bff88c/bin/../lib"
-  -L"/usr/local/lib/pony/0.9.0-e64bff88c/bin/../packages"
-  -L"/usr/local/lib" -lponyrt -lSystem
+```pony
+use "lib:Foo"
 ```
 
-The `ld` is the linker command that is usually used on MacOS or Linux. If I wanted to link in the library `Foo` and needed to pass `-lFoo` then I would compile my program as:
+If the library lives in a directory the linker doesn't search by default, add that directory with a `use "path:..."` statement:
 
-`ponyc --linker="ld -lFoo"`
-
-That would change the linker command that `ponyc` runs to:
-
-```bash
-ld -lFoo -execute -no_pie -dead_strip -arch x86_64 -macosx_version_min 10.8
-  -o ./timer ./timer.o -L"/usr/local/lib/pony/0.9.0-e64bff88c/bin/"
-  -L"/usr/local/lib/pony/0.9.0-e64bff88c/bin/../lib"
-  -L"/usr/local/lib/pony/0.9.0-e64bff88c/bin/../packages"
-  -L"/usr/local/lib" -lponyrt -lSystem
+```pony
+use "path:/opt/foo/lib"
+use "lib:Foo"
 ```
 
-### On Windows
-
-Compiling a pony program with `--verbose 3` will produce something like:
-
-```powershell
-cmd /C ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\bin\HostX64\x64\link.exe"
-  /DEBUG /NOLOGO /MACHINE:X64 /OUT:.\helloworld.exe .\helloworld.obj
-  /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.15063.0\ucrt\x64"
-  /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.15063.0\um\x64"
-  /LIBPATH:"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.11.25503\lib\x64"
-  /LIBPATH:"C:\pony\ponyc\build\release-llvm-3.9.1"
-  /LIBPATH:"C:\pony\ponyc\build\release-llvm-3.9.1\..\..\packages"
-  kernel32.lib msvcrt.lib Ws2_32.lib advapi32.lib vcruntime.lib legacy_stdio_definitions.lib dbghelp.lib ucrt.lib libponyrt.lib "
-```
-
-The path ending in `link.exe` is the linker that the pony compiler is currently using.
-
-To add options to the link command, I would compile my program as something like:
-
-`ponyc --linker="C:\OtherPath\link.exe /LIBPATH:C:\Foo"`
+These statements can go in any source file in your program, and they work the same on every platform.
 
 ## Does Pony support WebAssembly? {:id="wasm-support"}
 

--- a/docs/use/cross-compilation.md
+++ b/docs/use/cross-compilation.md
@@ -6,12 +6,7 @@ ponyc has built-in support for cross-compiling to Linux targets. The compiler em
 
 ## How It Works
 
-ponyc uses its embedded LLD linker for all Linux targets. Two conditions trigger this:
-
-1. No `--linker` flag is set.
-2. The target is Linux.
-
-If you do pass `--linker`, ponyc falls back to the legacy path and invokes that linker externally. This serves as an escape hatch if embedded LLD doesn't work for your situation.
+ponyc uses its embedded LLD linker for all Linux targets, both native and cross-compilation. There's nothing to enable. Linking happens in-process, with no external linker involved.
 
 ## What You Need
 
@@ -63,7 +58,6 @@ These flags control cross-compilation. Most are "rarely needed" in normal use, b
 | `--abi` | Target ABI (e.g., `lp64d`). Defaults to the host ABI. |
 | `--link-arch` | Linking architecture (e.g., `rv64gc`, `armv7-a`). |
 | `--sysroot` | Path to the target system root. Auto-detected from common cross-toolchain locations if not specified. |
-| `--linker` | Override the linker command. Bypasses embedded LLD and uses the specified external linker instead. |
 
 The `--sysroot` flag tells ponyc where to find the target's libc CRT objects and system libraries. If you don't specify it, ponyc searches these locations in order:
 


### PR DESCRIPTION
ponyc is removing the `--linker` and `--link-ldcmd` command line options (ponylang/ponyc#5452); embedded LLD is now the only linker. Update the docs that still describe `--linker`:

- `use/cross-compilation.md`: drop the `--linker` escape-hatch description and its flag-table row, and simplify "How It Works" to state that embedded LLD handles all Linux linking.
- `faq/compiling.md`: rewrite the "custom linker parameters" answer, which was built entirely on `--linker`, to point at `use "lib:..."` / `use "path:..."` for linking a library.

The blog posts that mention `--linker` are left as-is — they're dated, historical posts.

Should merge once ponylang/ponyc#5452 ships.
