### PR TITLE
Note the LLVM libs build cache in the GHCR infrastructure overview

### DIFF
--- a/docs/contribute/infrastructure.md
+++ b/docs/contribute/infrastructure.md
@@ -18,6 +18,8 @@ Access is via individual accounts which can then be granted various levels of ac
 
 All our docker images that are used across various CI and release jobs are stored in the GitHub Container Registry.
 
+We also use it as the cache for the compiler's vendored LLVM build. CI stores the prebuilt LLVM libraries there as OCI artifacts so jobs don't rebuild LLVM from scratch on every run.
+
 ## MailWip
 
 We have a paid account with [MailWip](https://mailwip.com/). All `@ponylang.io` email addresses are set up with MailWip that then forwards them on to a set of aliases.


### PR DESCRIPTION
The compiler's vendored LLVM build is moving from the GitHub Actions cache to GHCR OCI artifacts (ponyc#5484). The infrastructure overview's GitHub Container Registry section described only docker images; this adds a line recording that GHCR also holds the LLVM libs build cache, so the overview is accurate once that work lands.

Opened as a draft on purpose: it should not merge until ponyc#5484 is merged, since until then GHCR does not yet hold the libs cache and the new sentence would describe a state that doesn't exist.
