### PR TITLE
Sync ponyc CI tier docs with the current tier layout

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -1,46 +1,52 @@
 # ponyc CI Tiers
 
-ponyc organizes its CI into three tiers to balance fast feedback against comprehensive coverage. There's also a set of weekly checks that exist outside the tier system.
+ponyc organizes its CI into three tiers to balance fast feedback against comprehensive coverage. Tier 1 runs on every PR for fast feedback. Beyond that, the split tracks release-target status: Tier 2 holds the platforms we ship release binaries for, and Tier 3 holds platforms we test but don't ship. There's also a set of weekly checks that exist outside the tier system.
 
 ## Tier 1
 
-Tier 1 jobs run on every non-draft PR. These are the primary platforms that most users target and where regressions are most likely to be caught. A PR must pass all Tier 1 jobs before merging.
+Tier 1 jobs run on every non-draft PR. These are the primary platforms where we want fast feedback and where regressions are most likely to be caught. A PR must pass all Tier 1 jobs before merging.
 
-- x86-64 Linux (glibc and musl)
+- x86-64 Linux (musl)
 - arm64 macOS
 - x86-64 Windows
 
-Tier 1 jobs are defined in the [pr-ponyc](https://github.com/ponylang/ponyc/blob/main/.github/workflows/pr-ponyc.yml) workflow.
+For x86-64 Linux, the per-PR job builds against musl; the glibc build runs in Tier 2.
+
+Tier 1 jobs are defined in the [pr](https://github.com/ponylang/ponyc/blob/main/.github/workflows/pr.yml) workflow.
 
 ## Tier 2
 
-Tier 2 jobs are expensive and rarely catch issues that Tier 1 misses. They run on a daily schedule (1 AM UTC) rather than on every PR, gated on whether there were commits in the last 24 hours.
+Tier 2 covers the platforms we ship release binaries for that aren't already gated on every PR by Tier 1. They run on a daily schedule (1 AM UTC) rather than on every PR, gated on whether there were commits in the last 24 hours.
 
+- x86-64 Linux glibc (deb and rpm)
 - arm64 Linux (glibc and musl)
-- arm64 Windows
 - x86-64 macOS
-- `riscv64` Linux (cross-compiled)
-- arm Linux (cross-compiled)
-- armhf Linux (cross-compiled)
+- arm64 Windows
 
 Tier 2 jobs are defined in the [ponyc-tier2](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier2.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.
 
 ## Tier 3
 
-Tier 3 jobs test platforms where ponyc support is maintained on a best-effort basis. They run on a weekly schedule (Saturday 3 AM UTC), gated on whether there were commits in the last 7 days. These platforms run in QEMU-based VMs.
+Tier 3 covers platforms we test but don't ship release binaries for; support is best-effort. They run on a three-day-a-week schedule (Monday, Wednesday, and Friday at 2 AM UTC), gated on whether there were commits in the last 3 days.
 
+- `riscv64` Linux (cross-compiled)
+- arm Linux (cross-compiled)
+- armhf Linux (cross-compiled)
 - x86-64 FreeBSD 14.3
 - x86-64 FreeBSD 15.0
-- x86-64 OpenBSD 7.8
+- x86-64 OpenBSD 7.9
 - x86-64 DragonFly BSD 6.4.2
+
+The BSD platforms run in QEMU-based virtual machines. The cross-compiled Linux targets run in Docker containers under qemu-user emulation.
 
 Tier 3 jobs are defined in the [ponyc-tier3](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier3.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.
 
 ## Weekly Checks
 
-Weekly checks build and test with non-default compiler directives and sanitizers. They're valuable for catching breakage in code paths that don't get exercised during normal builds, but they rarely surface issues beyond confirming that nothing has been broken. They run on a weekly schedule (Sunday 3 AM UTC), gated on whether there were commits in the last 7 days.
+Weekly checks build and test with non-default compiler directives and sanitizers. They're valuable for catching breakage in code paths that don't get exercised during normal builds, but they rarely surface issues beyond confirming that nothing has been broken. They run on a weekly schedule (Thursday 3 AM UTC), gated on whether there were commits in the last 7 days.
 
 - Use directive variants (`dtrace`, `pool_memalign`, `pool_retain`, `runtimestats`, `runtime_tracing`)
 - Sanitizers (address sanitizer, undefined behavior sanitizer)
+- macOS sanitizer and `dtrace` smoke tests (arm64 and x86-64)
 
 Weekly checks are defined in the [ponyc-weekly-checks](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-weekly-checks.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.

--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -2,7 +2,7 @@
 
 Across a variety of repositories, we have a number of scheduled CI jobs. This document is an attempt to give a broad overview of what exists and when they run. Please note, this list is not guaranteed to be up-to-date and you should check various repos for final confirmation.
 
-The scheduled jobs list was last updated March 7, 2026.
+The scheduled jobs list was last updated June 14, 2026.
 
 <!-- markdownlint-disable -->
 
@@ -12,8 +12,10 @@ The scheduled jobs list was last updated March 7, 2026.
 | corral: nightly build | 00:00 | [ponylang/corral](https://github.com/ponylang/corral) |
 | ponyc: nightly build | 00:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: Tier 2 CI | 01:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: Tier 3 CI | 03:00 Sat | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: Weekly Checks | 03:00 Sun | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: Tier 3 CI | 02:00 Mon/Wed/Fri | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: Weekly Checks | 03:00 Thu | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: prune branch libs cache | 04:37 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: verify nightly image freshness | 06:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyup: nightly build | 00:00 | [ponylang/ponyup](https://github.com/ponylang/ponyup) |
 | rfc-tool: nightly build | 00:00 | [ponylang/rfc-tool](https://github.com/ponylang/rfc-tool) |
 | ponylang-website: verify site builds | 02:00 | [ponylang/ponylang-website](https://github.com/ponylang/ponylang-website) |


### PR DESCRIPTION
ponyc reorganized its CI tiers and changed several scheduled-job times, and the website's CI docs had drifted from the workflows. This brings `ponyc-ci-tiers.md` and `scheduled-jobs.md` back in line.

- Tier 1 is now x86-64 Linux musl, arm64 macOS, and x86-64 Windows; x86-64 Linux glibc moved off per-PR into Tier 2. Also fixed the dead `pr-ponyc.yml` link (the workflow is `pr.yml`).
- Tier 2 gains x86-64 Linux glibc (deb and rpm); the cross-compiled Linux targets moved down to Tier 3.
- Tier 3 gains riscv64, arm, and armhf; OpenBSD bumps to 7.9; the schedule is now Monday/Wednesday/Friday at 2 AM UTC with a 3-day change window. Corrected the "QEMU VMs" line — that's the BSDs; the cross targets run in Docker under qemu-user.
- Weekly checks moved to Thursday and gained the macOS sanitizer/dtrace smoke jobs.
- scheduled-jobs.md: corrected the Tier 3 and weekly-checks times and added the prune-branch-libs-cache and verify-nightly-image-freshness jobs.

Adopts ponyc's framing from [ponyc#5491](https://github.com/ponylang/ponyc/pull/5491): Tier 2 is the platforms we ship release binaries for, Tier 3 is the ones we test but don't ship.

A related doc gap turned up during the review — the BSD build pages understate DragonFly's configure-time rejection of sanitizers and dtrace. That's out of scope here and tracked in #1363.
