### PR TITLE
Add a supported-platforms matrix and correct the CI tiers wording

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -1,6 +1,6 @@
 # ponyc CI Tiers
 
-ponyc organizes its CI into three tiers to balance fast feedback against comprehensive coverage. Tier 1 runs on every PR for fast feedback. Beyond that, the split tracks release-target status: Tier 2 holds the platforms we ship release binaries for, and Tier 3 holds platforms we test but don't ship. There's also a set of weekly checks that exist outside the tier system.
+ponyc organizes its CI into three tiers to balance fast feedback against comprehensive coverage. The split tracks release-target status: Tier 1 and Tier 2 are both platforms we ship release binaries for — Tier 1 is the subset gated on every PR for fast feedback, and Tier 2 holds the rest, run on a schedule. Tier 3 holds platforms we test but don't ship release binaries for. There's also a set of weekly checks that exist outside the tier system.
 
 ## Tier 1
 
@@ -27,7 +27,7 @@ Tier 2 jobs are defined in the [ponyc-tier2](https://github.com/ponylang/ponyc/b
 
 ## Tier 3
 
-Tier 3 covers platforms we test but don't ship release binaries for; support is best-effort. They run on a three-day-a-week schedule (Monday, Wednesday, and Friday at 2 AM UTC), gated on whether there were commits in the last 3 days.
+Tier 3 covers platforms we test but don't ship release binaries for. They run on a three-day-a-week schedule (Monday, Wednesday, and Friday at 2 AM UTC), gated on whether there were commits in the last 3 days.
 
 - `riscv64` Linux (cross-compiled)
 - arm Linux (cross-compiled)

--- a/docs/faq/compiling.md
+++ b/docs/faq/compiling.md
@@ -2,7 +2,7 @@
 
 ## What are Pony's supported CPU platforms? {:id="supported-CPUs"}
 
-See [supported platforms](https://github.com/ponylang/ponyc?tab=readme-ov-file#supported-platforms) in the [ponyc](https://github.com/ponylang/ponyc) [README](https://github.com/ponylang/ponyc?tab=readme-ov-file).
+See [supported platforms](../learn/installing-pony.md#supported-platforms).
 
 ## I get a "requires dynamic" error when compiling, how do I solve it? {:id="pic-compile-error"}
 

--- a/docs/learn/installing-pony.md
+++ b/docs/learn/installing-pony.md
@@ -2,6 +2,26 @@
 
 The easiest way to install Pony is through [ponyup](https://github.com/ponylang/ponyup), Pony's toolchain manager. Ponyup handles installing and updating the Pony compiler and related tools.
 
+## Supported platforms
+
+<!-- Keep this matrix in sync with the copy in the ponyc repo: README.md -->
+
+| OS \ CPU | `amd64` | `arm64` | `arm32` | `riscv64` |
+|---|---|---|---|---|
+| **Linux** | ✅ Released | ✅ Released | 🧪 Tested | 🧪 Tested |
+| **macOS** | ✅ Released | ✅ Released | — | — |
+| **Windows** | ✅ Released | ✅ Released | — | — |
+| **FreeBSD** | 🧪 Tested | ✗ Unsupported | — | — |
+| **OpenBSD** | 🧪 Tested | ✗ Unsupported | — | — |
+| **DragonFly BSD** | 🧪 Tested | — | — | — |
+
+* ✅ **Released** — official prebuilt binaries; also tested in CI
+* 🧪 **Tested** — tested in CI; build from source (no prebuilt binary)
+* ✗ **Unsupported** — no support
+* — **Not applicable** — combination doesn't exist
+
+Platforms marked 🧪 Tested have no prebuilt binary; you'll need to [build ponyc from source](https://github.com/ponylang/ponyc/blob/main/BUILD.md).
+
 ## Install ponyup
 
 On Linux or macOS, run:
@@ -22,7 +42,7 @@ Prebuilt packages are only available for certain platforms. Check the [ponyc INS
 
 ## Additional dependencies
 
-On Linux, the Pony compiler requires a C compiler and may need additional libraries depending on your distribution. See the [ponyc installation instructions](https://github.com/ponylang/ponyc/blob/main/README.md#installation) for distro-specific details.
+On Linux, the Pony compiler requires a C compiler and may need additional libraries depending on your distribution. See the [ponyc installation instructions](https://github.com/ponylang/ponyc/blob/main/INSTALL.md) for distro-specific details.
 
 ## More information
 


### PR DESCRIPTION
Adds the supported-platforms matrix from the ponyc README to the install page, so someone can see whether their OS and CPU are covered without bouncing to GitHub. The same matrix is in a ponyc PR; an HTML comment in each copy points at the other.

Also:

- Repoints the FAQ's "supported CPU platforms" answer at the on-site matrix instead of the ponyc README.
- Fixes a dead link that pointed at a `README#installation` anchor that doesn't exist; it now points at `INSTALL.md`, which has the distro-specific details.
- Corrects the CI tiers doc. It described Tier 3 as best-effort, but those platforms run the full test suite on a schedule, so they're tested, not best-effort. The intro now states that Tier 1 and Tier 2 are the platforms that ship release binaries and Tier 3 is tested but not shipped.
