### PR TITLE
Add ponylang-prose-review and route the LWIP review through it

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,23 @@
+# `.claude/skills`
+
+Skills for working on the ponylang website with an AI assistant. Each lives in its own
+directory with a `SKILL.md`. They are self-contained — they don't depend on any personal or
+external skill, so a contributor with just this repo can use them.
+
+## Skills
+
+- **`lwip`** — write the weekly Last Week in Pony blog post. Rotates the open "Last Week in
+  Pony" issue, reads the week's collected items, verifies them, and drafts the post in the
+  format and voice defined in the repo's `AGENTS.md`. Step 8 of its workflow reviews the draft
+  with **`ponylang-prose-review`** before opening the post PR.
+
+- **`dev-sync-summary`** — turn a raw Pony Development Sync recap (for example a Zoom AI
+  summary) into a fact-checked comment on the open "Last Week in Pony" issue. It produces raw
+  material for the post, not the post itself; `lwip` later weaves the comment in.
+
+- **`ponylang-prose-review`** — ensemble review for ponylang blog and Last Week in Pony prose.
+  Runs lens reviewers in parallel — house voice, narrative, reader-orientation, tightness,
+  content-honesty, plus a conditional accuracy lens — checks the draft against the `AGENTS.md`
+  editorial guidelines and its own craft rules, and returns findings to apply (Fix) or raise
+  with the author (Park). Run it on any LWIP or blog draft before opening the post PR; `lwip`
+  invokes it as part of its workflow.

--- a/.claude/skills/dev-sync-summary/SKILL.md
+++ b/.claude/skills/dev-sync-summary/SKILL.md
@@ -71,9 +71,9 @@ recap of a group meeting, so "we" is the subject. Do **not** write it in the
 first person "I"; that voice belongs to the finished post, which `lwip` frames
 itself.
 
-Load the `seans-voice` skill for the voice. From this project's AGENTS.md, take
-only two things: the tone notes (Hemingway-esque, conversational, not clipped)
-and the `owner/repo` reference convention. Ignore the blog-post format in
+For the voice, follow the inline guidance above. From this project's AGENTS.md,
+take only two things: the tone notes (Hemingway-esque, conversational, not
+clipped) and the `owner/repo` reference convention. Ignore the blog-post format in
 AGENTS.md (front matter, `## Items of Note`, footer) — that is for the published
 post, not for a comment. AGENTS.md is already in context via the project
 CLAUDE.md, so reference it; do not copy it in.
@@ -142,9 +142,8 @@ requests** — check which before you link. (In the worked example below, "RFC
    - **Fabrication audit.** Re-read the draft. Every number, title, link,
      relationship, and characterization must trace to a source you verified this
      session. Anything that does not — verify it or cut it.
-   - **Voice self-review.** One anti-pattern at a time, per the `seans-voice`
-     skill: anthropomorphizing, unclear antecedents, AI tells, inflated claims,
-     choppy fact sequences.
+   - **Voice self-review.** One anti-pattern at a time: anthropomorphizing,
+     unclear antecedents, AI tells, inflated claims, choppy fact sequences.
 
 9. **Post the comment.** Write the body to a temp file under `~/tmp` (create the
    directory first with `mkdir -p ~/tmp` if it is missing) and post a new

--- a/.claude/skills/lwip/SKILL.md
+++ b/.claude/skills/lwip/SKILL.md
@@ -166,17 +166,18 @@ Follow these steps:
 7. **Write the draft**: Create the post following the format in AGENTS.md.
    Use the date from the issue title for the filename and front matter.
 
-8. **Review loop**:
-   a. Spawn a reviewer subagent (using Task tool, subagent_type
-      "general-purpose") with the copy-editing prompt from AGENTS.md. Pass
-      the full draft content. The reviewer has no conversation history — give
-      it everything it needs in the prompt.
-   b. For each finding: incorporate changes you agree with; if you disagree,
-      present the dispute to the user for a ruling.
-   c. If any changes were made, spawn a new reviewer on the updated content.
-   d. Repeat until a reviewer comes back clean.
-   e. If 3 rounds pass without a clean result, ask the user whether to
-      continue. Check in every 3 rounds thereafter.
+8. **Review**: Run the `ponylang-prose-review` skill on the draft (full
+   mode — a post is always more than two paragraphs). It runs the house-voice,
+   narrative, reader-orientation, tightness, and content-honesty lenses as
+   parallel reviewers (plus a conditional accuracy lens when the post has code
+   or technical claims), checks the draft against the AGENTS.md editorial
+   guidelines and the craft rules with the week's source bundle (the rotated
+   issue and its comments, linked posts, release notes, cited PRs/issues) in
+   hand, and runs the mechanical pre-check (cspell, `mkdocs build --strict`,
+   em-dash count, link sanity). Apply its Fix findings; for each Park finding,
+   incorporate it if you agree, or present the dispute to the user for a
+   ruling. The ensemble synthesizes in one pass — there's no per-round
+   re-spawn loop.
 
 9. **Commit and PR**: Create a branch, commit the new post with the message
    `Last Week in Pony - Month Day, Year`, and open a PR. Report the PR URL

--- a/.claude/skills/ponylang-prose-review/SKILL.md
+++ b/.claude/skills/ponylang-prose-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: ponylang-prose-review
+description: Ensemble review of ponylang blog and Last Week in Pony prose. Runs lens personas in parallel — house voice, narrative, reader-orientation, tightness, content-honesty, plus a conditional accuracy lens — checks the draft against the AGENTS.md editorial guidelines and the craft rules, and returns Fix/Park findings. Self-contained: no dependency on any other skill. Load after a draft exists, before the post PR.
+disable-model-invocation: false
+---
+
+# Review for ponylang prose
+
+The review that applies the ponylang Last Week in Pony house style and the craft rules to a
+draft with fresh, decorrelated eyes. A single generic copy-editor pass collapses every
+concern into "looks fine" and misses the failures that matter — enumeration instead of
+narrative, prose reproduced from a linked source, an invented framing, an unearned promise, a
+fabricated characterization, a wrong technical claim. This decomposes the review so each gets
+its own lens.
+
+This skill is **self-contained** — it loads no other skill. All the ensemble mechanics it
+needs are inlined below; nothing comes from `pony-ensemble` / `pony-synthesize` or any
+personal skill. A contributor with only this repo's `.claude/` can run it.
+
+## When to run
+
+After a draft of ponylang prose exists, before it ships:
+
+- Last Week in Pony posts (the main case).
+- Other ponylang blog posts.
+- The Pony Development Sync issue comment produced by `dev-sync-summary`, if you want more
+  than its built-in self-review.
+
+## Two rulebooks this skill reads
+
+- **The AGENTS.md "Last Week in Pony" section** — the house voice (tone, em-dash frugality,
+  backtick technical terms, Office Hours singular, `owner/repo` naming, conversational not
+  clipped). The House-voice persona reads it.
+- **`references/craft-rules.md`** (alongside this skill) — narrative, reader-orientation,
+  tightness, content-honesty/source-fidelity. The other craft personas read the relevant
+  sections.
+
+## Mode selection by size
+
+Count the draft's **prose paragraphs**: blank-line-separated blocks of running prose. Do not
+count fenced code blocks, YAML front matter, headings, or list items.
+
+```
+PARAGRAPH_THRESHOLD = 2
+```
+
+- **> 2 prose paragraphs → full review.** The five-lens ensemble below — six when the draft
+  has code or technical claims, where the conditional Accuracy lens joins. A post is always
+  full.
+- **≤ 2 prose paragraphs → cheap inline pass.** No subagents. The orchestrator reads the
+  draft once against the AGENTS.md house style and the content-honesty section of
+  `craft-rules.md` (pulling the source bundle if a claim needs checking), plus the mechanical
+  pre-check, and returns Fix/Park findings directly.
+
+`PARAGRAPH_THRESHOLD` is one line on purpose — move it when the size heuristic misjudges an
+artifact.
+
+## Source bundle
+
+The content-honesty and tightness personas can only catch fabricated claims, flattened source
+voice, and reproduced-source if they have the source. Assemble it per artifact and hand it to
+**both** of those personas (the house-voice, narrative, and orientation personas work from the
+draft and their rulebook):
+
+| Artifact | Source bundle |
+|---|---|
+| LWIP post | the rotated issue + all its comments; linked prior posts; release notes (`gh release view`); linked PRs/issues (`gh`) |
+| other blog post | linked posts; release notes / `gh release view`; the originating discussion or issue |
+| dev-sync comment | the raw summary; the linked PRs/issues/RFCs (`gh`) |
+
+A raw meeting summary and machine-generated recaps are leads to verify, not copy — pull facts
+from them, never trust their wording or their number-to-title mapping.
+
+## Mechanical pre-check (scripted, not an agent)
+
+Run before spawning personas; feed results to synthesis. LWIP and blog posts live in this
+repo's buildable, cspell'd site, so all of these apply:
+
+- **cspell** over the file.
+- **`mkdocs build --strict`** (set up the venv per the project README/CLAUDE.md if needed).
+- **em-dash count** (flag heavy use).
+- **link-target sanity** — does each link's text match what it points at?
+
+For a dev-sync issue comment (not a repo file): em-dash count + link sanity only.
+
+## Full process
+
+1. **Identify the artifact and assemble the source bundle** (tables above).
+2. **Run the mechanical pre-check.** Capture results.
+3. **Make an evidence dir:** `~/tmp/prose-review-<timestamp>/`. Each persona writes its
+   detailed evidence to a file there; pass the path in the prompt.
+4. **Spawn the lens personas in parallel**, each a fresh-context subagent on your most capable
+   model. Five always run: House-voice, Narrative, Orientation, Tightness, Content-honesty. A
+   sixth, **Accuracy**, joins **only when the draft has code or makes technical/behavioral
+   claims about a system** (compiler internals, an API, a release); skip it otherwise. Each
+   prompt includes:
+   - The persona document, read from `personas/<lens>.md`.
+   - Its rulebook slice: the **House-voice** persona gets the AGENTS.md "Last Week in Pony"
+     section and 2–3 recent posts from `docs/blog/posts/` for calibration; the Narrative,
+     Orientation, Tightness, and Content-honesty personas get the relevant sections of
+     `references/craft-rules.md`. The **Accuracy** persona reads the actual source instead.
+   - The draft in full.
+   - For the **Content-honesty** and **Tightness** personas: the full source bundle.
+   - For the **Accuracy** persona: the source the draft describes (the repo/files, release
+     notes, the version it targets).
+   - The shared persona output format (below).
+   - "You are an ensemble agent — return findings to the orchestrator, take no external
+     actions, edit nothing."
+5. **Triage persona outputs** — confirm each addressed the actual draft and stayed on its
+   lens. Drop nothing silently.
+6. **Synthesize** (inlined below).
+7. **Triage into Fix / Park** and act (below).
+
+## Shared persona output format
+
+Include in every persona prompt. Each persona produces two artifacts.
+
+**Evidence file** (written to the provided path): every finding with the exact quoted text
+from the draft, what's wrong, the rule it violates, and the concrete rewrite.
+
+**Summary** (returned to the orchestrator):
+
+- **Findings**, ordered by severity (Blocking > Should-fix > Minor). Each:
+  - **Quote**: the exact span from the draft.
+  - **Lens**: this persona.
+  - **Problem**: what's wrong (concise — full reasoning is in the evidence file).
+  - **Fix or Park**: is the right change obvious (Fix), or does it need the author's judgment
+    (Park)? With the suggested rewrite (Fix) or the question (Park).
+- **Passes**: key things checked that read true. Brief.
+- **Uncertainties**: anything the persona couldn't judge without the author or more source.
+
+## Synthesis (inlined)
+
+The synthesizer is a fresh-context agent (or the orchestrator) given all persona summaries and
+the mechanical-check results, with these instructions:
+
+**Job:** integrate the persona findings into one deduplicated list. You are not averaging
+opinions — you are assembling the strongest, non-redundant set of findings.
+
+**Focus:**
+- **Don't drop anything.** Every persona finding appears in the output or is explicitly merged
+  into another. A review that surfaces a real problem and then loses it has wasted the
+  discovery.
+- **Cross-persona corroboration is high-confidence.** When two personas flag the same span
+  from different angles, merge them into one finding marked high-confidence — never let each
+  assume the other owns it and drop both.
+- **Clusters signal structure.** Several small findings in one section often mean the section's
+  shape is wrong (an enumeration, a reproduced source, a missing on-ramp). Call out the
+  structural problem, not just the symptoms.
+- **Severity stands.** If one persona says Blocking with evidence and another didn't mention
+  it, it's Blocking. Don't soften by consensus.
+
+## Fix / Park triage
+
+Categorize every finding. Nothing is silently dropped.
+
+- **Fix** — the right change is obvious: a misspelling, an unclear antecedent, a term used
+  before it's introduced, an enumeration to reweave, prose reproduced from the linked source,
+  an unbackticked technical term, an em-dash glut, a fabricated characterization to cut.
+  Apply these directly.
+- **Park** — needs the author: a framing or thesis the draft asserts that no source supports,
+  a thematic hook, a tone call, a metaphor to keep or cut. **Never ship a parked call as
+  final.** Batch parked items and present them as questions.
+
+When run inside the `lwip` pipeline: apply the Fix items, list the Park items for the author,
+and proceed. When run standalone: return both lists.
+
+## Output format
+
+```
+## Prose review — <artifact>  (<full | inline pass>, N findings)
+
+### Applied (Fix)
+- <quote> → <change>  [lens]
+...
+
+### Raise with the author (Park)
+- <quote> — <the question>  [lens]
+...
+
+### Mechanical
+- cspell: <clean | issues>   build: <pass | fail>   em-dashes: <count>   links: <ok | …>
+
+### Passes
+- <brief confidence notes>
+```
+
+## The lenses
+
+| Persona | Catches |
+|---|---|
+| `house-voice.md` | ponylang LWIP house style: tone (Hemingway, conversational not clipped), em-dash frugality, backtick technical terms, Office Hours singular, `owner/repo` naming, AI tells, clipped-imperative cadence. Reads the AGENTS.md guidelines; calibrates on recent posts. |
+| `narrative.md` | enumeration vs story, at section **and** prop level (a snippet/line-count/parenthetical can be dead cargo inside a good section). |
+| `orientation.md` | concept-before-use, unclear antecedents, missing on-ramps, offloaded context, compressed recaps that strip framing, missing prerequisites. |
+| `tightness.md` | reproduced linked source, props that don't earn their place, filler, wrong altitude for the artifact. **Gets the source bundle.** |
+| `content-honesty.md` | unsourced or fabricated claims, invented framing, invented quantitative characterizations, unearned promises, flattened source personality, lifted wording from unvetted sources, authorship/tense honesty. **Gets the source bundle.** |
+| `accuracy.md` | **conditional** — runs only when the draft has code or technical/behavioral claims. Verifies code, API signatures, behavior and version claims, PR/issue numbers and titles against the actual source. |

--- a/.claude/skills/ponylang-prose-review/personas/accuracy.md
+++ b/.claude/skills/ponylang-prose-review/personas/accuracy.md
@@ -1,0 +1,38 @@
+# Accuracy persona
+
+You are the technical-accuracy reviewer. You check one thing: is the draft's technical content
+actually *true* against the real source — code examples, API signatures, claims about how a
+system behaves, and the PR/issue/RFC numbers and titles it cites? Not your job: voice,
+narrative, whether claims match the *source bundle* (that's content-honesty's "did you
+represent the source faithfully" — you check the harder question, "is it correct against ground
+truth").
+
+**You are conditional.** If the draft has no code and makes no technical/behavioral claims —
+a community-news roundup with nothing to verify beyond what content-honesty already checks —
+say so in one line and return. Only spin up when there's something checkable.
+
+You are given the source the draft describes: the repo/files for a code example, the release
+notes / API for a feature claim, the version it targets, the PRs/issues it cites. Read the
+actual source; do not verify from memory of what an API "probably" looks like.
+
+## Read for each
+
+- **Code examples against source.** Do the APIs the example uses exist? Are the method
+  signatures, argument order, and types correct against the current implementation? Would it
+  compile/run? An example that worked one release ago but not now is a finding.
+- **Technical/behavioral claims.** "X does Y," "the runtime Z's after the call returns," "this
+  is O(n)." Verify each against the source or authoritative docs. A claim that reads plausibly
+  and is wrong is the highest-value catch.
+- **PR/issue/RFC numbers and titles.** LWIP prose is full of `owner/repo NNNN` citations.
+  Verify each number resolves, that the title matches, and that an RFC linked as a PR isn't
+  actually an issue (or vice versa) — with `gh`. A transposed digit or a guessed title is a
+  finding.
+- **Version-specific claims.** "As of version N…," "since the 0.x release…" — correct for the
+  version the post targets? Check the release notes / changelog.
+
+## Output
+
+Shared persona format. For each finding, quote the draft's technical span, cite the source
+(file:line, the signature, the release note, the `gh` result) that contradicts it, and give the
+correction. Technical errors are almost always Fix. A claim you can't resolve against available
+source is an Uncertainty, not an invented verdict — flag it rather than guessing.

--- a/.claude/skills/ponylang-prose-review/personas/content-honesty.md
+++ b/.claude/skills/ponylang-prose-review/personas/content-honesty.md
@@ -1,0 +1,47 @@
+# Content-honesty persona
+
+You are the content-honesty and source-fidelity reviewer. You check one thing: is every claim
+true to a source, and is nothing invented or flattened? Not your job: voice, narrative,
+orientation — only honesty. You are given the **source bundle** (issue comments, linked posts,
+release notes, the diff — whatever applies); you cannot do your job without it, so read it
+first.
+
+Your rulebook is the "Content honesty and source fidelity" section of `craft-rules.md`.
+
+## Read against the source, item by item
+
+- **Unsourced claim.** Any characterization of history, severity, duration, impact, size, or
+  frequency. Check it against the source bundle. If the source doesn't support it, flag it.
+  Apply the content-first test to every flair sentence: cover the colorful part — if no
+  checkable fact remains, it's empty.
+- **Invented quantitative characterization.** "Smaller crowd than usual," "a larger turnout,"
+  "more than usual," "rarely." Verify against the source or flag for flattening to a plain
+  statement.
+- **Invented framing / thesis / observation.** A connecting thread, thematic hook, or authorial
+  feeling the draft asserts that no source supports. This is the highest-value catch. It is a
+  **Park**, not a Fix: the question for the author is "is this your read, or invented?" Never
+  let an invented framing ship as theirs.
+- **Unearned promise.** A forward reference ("I'll save the story for below," "more on that
+  later") with no payoff. Check that the promised thing actually appears. If not, the promise is
+  cut.
+- **Flattened source personality.** Compare the draft to the source's wording. Where the source
+  had human voice — a colloquialism ("just cause"), "I give you," self-referential humor,
+  genuine enthusiasm — and the draft sanded it flat, flag it. The fix is to restore the
+  source's energy.
+- **Lifted wording from an unvetted source.** GitHub issues, discussions, and machine-generated
+  recaps are often LLM-written or lossy. If the draft's phrasing tracks an issue/discussion's
+  wording (twee, anthropomorphized), flag it — facts from those sources, never their phrasing.
+  And never trust their number-to-title mapping; verify with `gh`.
+- **Authorship / tense honesty.** If `git log` / the source shows the author wrote or maintains
+  the thing, the draft should own it in first person, not passive. Still-existing practices and
+  options in present tense; past tense only for what the change removed.
+- **Obvious dressed as thesis; snark; strawman.** A truism built into a thesis or closer; a
+  caricature (careless users, dumb tooling); one path presented as inevitable when alternatives
+  exist. Name the real options and honest costs. When in doubt, Park.
+
+## Output
+
+Shared persona format. For each finding, quote the draft span, quote or cite the source (or
+note its absence), and give the fix or the question. Unsourced claims, flattened colloquialisms,
+unearned promises, lifted wording → usually Fix. Invented framing/thesis and anything plausibly
+the author's deliberate call → Park.

--- a/.claude/skills/ponylang-prose-review/personas/house-voice.md
+++ b/.claude/skills/ponylang-prose-review/personas/house-voice.md
@@ -1,0 +1,39 @@
+# House-voice persona
+
+You are the house-voice reviewer. You check one thing: does this draft match the ponylang Last
+Week in Pony house style? Nothing else is your job — not accuracy, not narrative shape, not
+reader orientation. Just the voice and the house conventions.
+
+Your rulebook is the "Last Week in Pony" section of this repo's `AGENTS.md` (provided). Your
+calibration is recent posts in `docs/blog/posts/` — read 2–3 first; they are what the house
+voice actually sounds like.
+
+## Read the draft once for each of these, separately
+
+A general "does this sound right?" pass catches almost nothing. Go through the draft once per
+item, looking only for that item, and produce concrete instances with rewrites — or an explicit
+"none."
+
+- **Tone.** Informal, Hemingway-esque, short sentences, conversational — but **not** clipped or
+  a series of notes. It should read like a person talking to you. Flag both flat/telegraphic
+  prose and flowery, over-adjectived prose.
+- **Em-dash frugality.** A few per post is fine; heavy use reads AI-generated. Prefer a period,
+  comma, colon, or parentheses when one works as well. Never double hyphens (`--`).
+- **Backtick technical terms.** Type names, function names, system calls, language keywords go
+  in backticks: `HashMap`, `writev`, `None`. Flag unbackticked technical terms.
+- **Office Hours is singular.** "Office Hours was attended by…", not "were."
+- **`owner/repo` naming.** Repositories as `owner/repo` on first mention and in section
+  headings (`ponylang/ponyc`, not a bare `ponyc`); a lowercase short name is fine in later
+  prose.
+- **AI tells.** "It's worth noting," "importantly," "interestingly," overly balanced hedging.
+- **Clipped-imperative cadence.** Repeated command openers (Drop / Put / Run / Set a `.c`…).
+  One for punch is fine; a cadence of them reads as telling someone what to do, not chatting.
+  Vary with declaratives that breathe.
+- **Opening hook.** It should unfurl naturally, not read as a bulleted list of the post's
+  topics.
+
+## Output
+
+Shared persona format. For each finding, quote the exact span, name the item, and give the
+rewrite. Most house-voice fixes are Fix (the rewrite is obvious); a genuine tone call the author
+should make is a Park.

--- a/.claude/skills/ponylang-prose-review/personas/narrative.md
+++ b/.claude/skills/ponylang-prose-review/personas/narrative.md
@@ -1,0 +1,31 @@
+# Narrative persona
+
+You are the narrative reviewer. You check one thing: does each section tell a story, or
+enumerate? An enumeration reads mechanical even when every sentence is fine on its own. Not your
+job: voice, accuracy, orientation — only whether there's a thread.
+
+Your rulebook is the "Narrative, not enumeration" section of `craft-rules.md`.
+
+## Two passes, not one
+
+**Section level.** Walk each section. Is it problem → answer → next problem → next answer, with
+the parts connected by cause/effect, contrast, or significance? Or is it "also, here's another
+thing" repeated? Test: could you turn the paragraph into bullets and lose nothing? If yes, it's
+an enumeration — say so, and show the thread that would connect it.
+
+**Prop level.** This is the pass that gets skipped. Inside a section that *has* narrative shape,
+does every prop earn its place, or is some of it dead cargo? Challenge each:
+- code snippet — does the reader need the code, or is "X calls Y" prose enough?
+- line-count / file path / named struct — load-bearing, or grounding for grounding's sake?
+- explanatory parenthetical — does the audience care, or are you showing your work?
+- enumerated list — each item earning its place, or padding to look thorough?
+
+A section can read as a fine story while a snippet or a "1500 lines of C" inside it advances
+nothing. Flag the prop, not just the section.
+
+## Output
+
+Shared persona format. For each finding, quote the span (or name the prop), say whether it's a
+section enumeration or a dead prop, and give the fix — the thread to add, or the prop to cut.
+Reweaving an enumeration and cutting dead cargo are usually Fix; a genuine "is this whole
+section pulling its weight?" structural question is a Park.

--- a/.claude/skills/ponylang-prose-review/personas/orientation.md
+++ b/.claude/skills/ponylang-prose-review/personas/orientation.md
@@ -1,0 +1,34 @@
+# Orientation persona
+
+You are the reader-orientation reviewer. You read the draft as someone seeing this subject for
+the first time, and you check one thing: can that reader follow it? Not your job: voice,
+narrative shape, accuracy — only whether the reader has what they need, when they need it.
+
+Your rulebook is the "Reader orientation" section of `craft-rules.md`.
+
+## Read the draft as a first-time reader, once per item
+
+- **Concept used before it's introduced.** A subject-specific term — a function, a pass, a
+  tool, a data structure — relied on before it's taught. Mark every spot where a fresh reader
+  hits "wait, what's that?" on a load-bearing term. (A term used only as a list example, not
+  relied on, does not need a gloss — don't flag those.)
+- **Rushed inflection point.** The key idea or key bug compressed into one bridging sentence.
+  If the reader needs to understand it for the rest to work, it needs room.
+- **Unclear antecedent.** Every "it"/"this"/"that" whose referent isn't in the same or previous
+  sentence. Also capacious words ("main," "the work," "tooling") used before they're anchored.
+- **Missing on-ramp.** A section that opens mid-mechanism with nothing to stand on. The reader
+  needs a beat that lands what the section is about before the details.
+- **Offloaded context.** "Go read the other post for context" where the context is load-bearing
+  and belongs inline.
+- **Compressed recap that strips framing.** A one-sentence recap of prior content that drops a
+  qualification the original was careful about.
+- **Series-framing over the reader's question.** Opening on "third post in…" / "part of the
+  series" instead of the audience's question about this specific subject.
+- **Missing prerequisite or skipped step.** For procedural or how-to content, walk the reader's
+  path: a prerequisite the piece relies on but never states, or a step the reader needs that's
+  skipped.
+
+## Output
+
+Shared persona format. For each finding, quote the span, name the item, and give the fix — the
+bring-forward sentence, the antecedent to name, the on-ramp to add. Most are Fix.

--- a/.claude/skills/ponylang-prose-review/personas/tightness.md
+++ b/.claude/skills/ponylang-prose-review/personas/tightness.md
@@ -1,0 +1,28 @@
+# Tightness persona
+
+You are the tightness reviewer. You check one thing: is this the right amount, at the right
+altitude, with nothing reproduced or padded? Not your job: voice, narrative thread, accuracy —
+only whether the piece is tight.
+
+Your rulebook is the "Tightness and altitude" section of `craft-rules.md`. You are given the
+source bundle too, because the main tightness failure is reproducing a linked source.
+
+## Read for each
+
+- **Reproduced linked source.** When the draft links to a full post, release notes, or a
+  discussion, compare the draft's prose to that source. A highlight or summary should point and
+  compress, not restate the linked thing. If a paragraph reproduces what it links to, flag it —
+  the work is done by the link; the draft should summarize.
+- **Wrong altitude.** An LWIP highlight written at the length of the post it links. A short
+  artifact carrying a long artifact's machinery. Name the altitude mismatch and the cut.
+- **Filler and padding.** Sentences that restate the prior one, throat-clearing, hedges that
+  add nothing, props that pad to look thorough.
+
+Distinguish tightness from orientation: if context is *missing*, that's Orientation's; if
+context is *duplicated* (from the link, from earlier in the piece, from itself), that's yours.
+
+## Output
+
+Shared persona format. For each finding, quote the span, say what it duplicates or pads, and
+give the cut or the compression. Most are Fix; a "should this section exist at all?" call is a
+Park.

--- a/.claude/skills/ponylang-prose-review/references/craft-rules.md
+++ b/.claude/skills/ponylang-prose-review/references/craft-rules.md
@@ -1,0 +1,138 @@
+# Craft rules
+
+The non-voice rules for ponylang blog and Last Week in Pony prose: narrative, reader
+orientation, tightness, content honesty. The AGENTS.md "Last Week in Pony" section holds the
+voice rules (tone, em dashes, backticks, naming); this holds the craft (how a piece is built
+and whether it's honest). The Narrative, Orientation, Tightness, and Content-honesty personas
+check against the matching section here.
+
+---
+
+## Narrative, not enumeration
+
+**Each section is a story, not a list.** A paragraph of independent facts separated by periods
+is a bullet list without the bullets. The shape is: a problem the reader hits → its answer →
+the next problem → its answer. If every paragraph reduces to "also, here's another thing," it's
+an enumeration. Connect by cause/effect, contrast, significance — the reader should feel a
+thread pull them through, not a checklist they're walked down.
+
+*Why:* an enumeration reads mechanical even when every sentence is fine on its own.
+
+**Check the props, not just the sections.** A section can have narrative shape while a prop
+*inside* it earns nothing: a code snippet copied because earlier posts had one, a "1500 lines
+of C" line-count, a pipeline-position parenthetical, an enumeration the linked doc already
+covers. Run two passes — does each *section* advance the point, and does each *prop within it*
+advance the point? Challenge every snippet ("does the reader need the code, or is 'X calls Y'
+enough?"), line-count, named struct, explanatory parenthetical, and enumerated list. A
+narrative-shape check at the section level misses load-free decoration inside a "good" section.
+
+---
+
+## Reader orientation
+
+**Introduce a concept before you rely on it; let it breathe.** A codebase-specific term — a
+function name, a pass, a data structure — named once in a compressed clause is not taught. The
+reader hasn't read the source; the piece exists to teach them. Spend real words on a
+load-bearing concept: what it is, when it runs, why it exists. Introduce, then name (concept
+first, label second), with a beat of room — not a clause. *Boundary:* a term used purely as a
+list example, one the reader doesn't need to hold for the point to land, does not need a gloss;
+explaining it would be a tangent. General CS (DFS, hashmap) stays light; *this* subject's
+specific concepts need genuine setup. Kill vague hand-waves ("a mental shift more than a code
+change") — state the concrete thing.
+
+**Bring prior-content context forward.** For a follow-up or series piece, the on-ramp must work
+for someone who hasn't read the earlier piece while staying interesting to someone who has.
+Don't write "the wrapper from the previous post hands you a function" cold. Bring each
+load-bearing concept forward in one dense, natural sentence where it first matters — enough that
+a fresh reader can follow, light enough that a returning reader isn't re-lectured. Not a "Recap
+of last post" header.
+
+**Don't offload context.** "Go read the other post for context" tells the reader you're not
+giving them what they need here. If something matters to the piece, the piece says it. Bring the
+relevant context inline. (A one-line teaser of a prior post, or a navigation link, is fine —
+offloading the load-bearing context is not.)
+
+**A compressed recap can strip the original's framing.** The one-sentence recap is where
+careful framing gets dropped — the original may have flagged an analogy *as* a metaphor, drawn a
+distinction, or stepped around a trap. Before writing a recap, name what the original was
+careful about and preserve it, even when compressing. Two sentences if one won't hold it.
+
+**Write for the reader's question, not the series.** Series/project narrative is the writer's
+scaffolding, not the reader's content. Someone landing on a post about X wants to know about X —
+what it is, why it exists, what it means for them — not that it's the fourth in an internal arc.
+Open on the audience's likely question about *this* subject; if the broader arc matters, it's
+one sentence of context inside the piece, not a frame around it; close on the piece's own point.
+
+**Every "it"/"this"/"that" has an obvious referent.** If the antecedent isn't in the same or
+previous sentence, name the thing. Unclear antecedents are a failure of craft. Same for
+capacious words ("main," "the work," "tooling," "scale") used before they're anchored — a pivot
+that depends on the reader reading an abstraction the way you meant won't land.
+
+**Don't skip a prerequisite or step.** For procedural or how-to content, walk the reader's path:
+is there a prerequisite (a tool, a setting, prior knowledge) the piece relies on but never
+states, or a step the reader needs that's skipped? A gap the reader can't cross is a finding.
+
+---
+
+## Tightness and altitude
+
+**Don't reproduce what you link to.** When a piece links to a full post / release notes /
+discussion, summarize and point — don't reproduce the linked thing's content. A highlight that
+links to the full write-up should be a tight summary, not a second copy of it. Most of the work
+is done by the thing you linked.
+
+**Right altitude for the artifact.** A commit message is "why," not a tour. An LWIP highlight is
+a paragraph, not the linked post. Cut filler. Every prop earns its place (see Narrative, prop
+level).
+
+---
+
+## Content honesty and source fidelity
+
+**Every claim traces to a source.** Characterizations of history, severity, duration, impact,
+size, frequency are factual claims. Verify from the issue/PR/release notes/git log, or drop.
+This is the hardest failure to catch because a sentence can nail the rhythm and humor and still
+assert something unverified. Test: cover the colorful part of the sentence; if a checkable fact
+remains, it earns the flair; if nothing's left, it's empty — write the real fact in or cut it.
+
+**Don't invent quantitative characterizations.** "Smaller crowd than usual," "a larger
+turnout," "more than usual," "rarely," "frequently" all assert facts. "Three at Office Hours" is
+normal unless a source says otherwise. Verify or state flatly with no comparison.
+
+**Don't invent a framing, thesis, or observation and present it as the author's.** A connecting
+thread or thematic hook the author didn't state, asserted as their view, is fabrication — the
+same as inventing a fact. If a piece would read better with a thread the author hasn't given,
+flag it as a question, never assert it. An authorial feeling no source supports ("the quiet ones
+worry me more") is a Park, not a Fix.
+
+**No unearned promises.** "I'll save the story for below" with no story below; "more on that
+later" that never arrives. A forward reference has to be paid off. If the payoff doesn't exist,
+cut the promise.
+
+**Amplify the source's personality; don't flatten it.** When source material (issue comments,
+notes, a theme-song blurb) has human voice — colorful phrasing, "I give you," self-referential
+humor, genuine enthusiasm, a colloquialism like "just cause" — that's raw material to keep and
+amplify, not "clean up" into flat declarative prose. Flattening a source colloquialism is a
+finding. If anything, add more human, not less.
+
+**Facts from unvetted sources, never their wording.** GitHub issues, discussions, and
+machine-generated meeting recaps are often LLM-written or lossy — pull facts and meaning, never
+phrasing, and never trust their number-to-title mapping (verify with `gh`). Lifting wording from
+a design doc imports its (often twee/anthropomorphized) register straight past every voice pass,
+because the source looks authoritative. Calibrate voice only on vetted, published posts.
+
+**Authorship and tense honesty.** When the author wrote or maintains the thing, the piece owns
+it in first person — "I didn't touch it for a couple years," not the passive "it didn't receive
+updates." (Check `git log` before assuming authorship.) Describe practices and still-existing
+options in present tense; past-tense only the one thing the change actually removed or replaced.
+Both can sit in one piece: "Pony **had** no concept of C code" (past — it does now) next to the
+present-tense options that persist.
+
+**The obvious is not a thesis.** A truism the audience already holds ("a compiler shouldn't
+crash on invalid input") is not an insight — don't build a section or closer on it, and don't
+credit it to whoever said it in passing. State the relevant fact and move on; let the genuinely
+non-obvious idea carry the weight.
+
+**No snark or strawmen.** Don't caricature (careless users, dumb tooling) and don't present one
+path as inevitable when alternatives exist. Name the real options and their honest costs. (Voice
+reviewers will confidently praise snark as the "best" line — it isn't; when in doubt, Park it.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ Study recent posts in `docs/blog/posts/` for voice calibration before writing.
 - Refer to repositories as `owner/repo` (e.g., `seantallen-org/msgpack`, not
   `msgpack`) — no one owns a name. This applies everywhere: section headings,
   inline prose, not just the releases list. Link to the repo on first mention.
+- Em dashes (—) are fine but use them sparingly. Heavy use reads as
+  AI-generated. Prefer a period, comma, colon, or parentheses when one works
+  just as well. Never replace an em dash with double hyphens (`--`).
+- Technical terms (type names, function names, system calls, language keywords)
+  go in backticks: `HashMap`, `writev`, `None`, not HashMap, writev, None.
+- The opening hook should unfurl naturally, not read as a bulleted list of
+  topics.
 
 ### Post Format
 
@@ -102,31 +109,11 @@ _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for
 Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 ```
 
-### Reviewer Prompt
+### Review
 
-When spawning a copy-editing reviewer subagent, use a prompt along these lines:
-
-> You are a copy editor reviewing a "Last Week in Pony" blog post. Check for
-> grammar, spelling, clarity, and concision. The tone should be informal and
-> Hemingway-esque. Short sentences. Conversational, not clipped. Avoid flowery
-> language, minimize adjectives and adverbs except where they serve the tone.
-> The result should read like a person talking to you, not like AI output.
->
-> Style conventions for this project:
->
-> - Em dashes (—) are fine but use them sparingly. Heavy em dash use reads as
->   AI-generated. If a period, comma, colon, or parentheses works just as
->   well, prefer that. Do NOT replace em dashes with double hyphens (--).
-> - Technical terms (type names, function names, system calls, language
->   keywords) should be in backticks: `HashMap`, `writev`, `None`, not
->   HashMap, writev, None.
-> - Repositories are referred to as `owner/repo` (e.g., `ponylang/ponyc`, not
->   just `ponyc`) on first mention and in section headings. Short names in
->   lowercase are fine in subsequent prose.
-> - "Office Hours" is the title of a meeting and is singular ("Office Hours
->   was attended by..." not "Office Hours were attended by...").
-> - The opening hook should unfurl naturally, not read as a bullet list of
->   topics.
->
-> Leave the mkdocs metadata as is. Return the full corrected markdown and then
-> list what changes you made and why.
+Review the draft with the `ponylang-prose-review` skill before opening the
+post PR (see `.claude/README.md`). It runs an ensemble of lens reviewers —
+house voice, narrative, reader-orientation, tightness, content-honesty, plus a
+conditional accuracy lens — against these editorial guidelines and the craft
+rules, and returns findings to apply or raise. It replaces the single
+copy-editing pass this section used to describe.


### PR DESCRIPTION
Adds `ponylang-prose-review`, an ensemble review for Last Week in Pony and other ponylang blog prose, and routes the `lwip` skill's review through it.

The LWIP review was a single copy-editor subagent: one pass over grammar, tone, and a few house conventions, looped until clean. A single generic pass collapses every concern into "looks fine" and misses the structural and honesty failures that matter — a section that enumerates instead of telling a story, prose reproduced from the post it links to, a fabricated characterization, an unearned promise, a wrong PR number.

`ponylang-prose-review` decomposes the review into one lens per fresh-context reviewer — house voice, narrative, reader-orientation, tightness, content-honesty, plus a conditional accuracy lens when the draft has code or technical claims — run in parallel, synthesized, and triaged into findings to apply (Fix) and findings to raise with the author (Park). The house-voice lens reads the AGENTS.md editorial guidelines; the craft lenses read the skill's own `references/craft-rules.md`; content-honesty and tightness get the week's source bundle so they can check claims and catch reproduced source. It scales by size — a full ensemble for a post, a cheap inline pass for short prose — and runs the repo's mechanical checks (cspell, `mkdocs build --strict`, em-dash count, link sanity). It loads no other skill, so any contributor with this repo can run it.

Supporting changes: the three house-style rules that lived only in the deleted copy-editor prompt — backtick technical terms, em-dash frugality, "opening hook isn't a bulleted list" — move into the AGENTS.md editorial guidelines, so the house-voice lens still enforces them. `lwip` step 8 now runs the skill instead of the single-agent loop. `dev-sync-summary` drops its two references to a personal voice skill, relying on its inline guidance plus AGENTS.md, so the repo's skills are self-contained. A new `.claude/README.md` maps the three skills and points LWIP authors at the review.
