### PR TITLE
Update ponyc stress-test schedule times

### DIFF
--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -2,7 +2,7 @@
 
 Across a variety of repositories, we have a number of scheduled CI jobs. This document is an attempt to give a broad overview of what exists and when they run. Please note, this list is not guaranteed to be up-to-date and you should check various repos for final confirmation.
 
-The scheduled jobs list was last updated June 14, 2026.
+The scheduled jobs list was last updated June 23, 2026.
 
 <!-- markdownlint-disable -->
 
@@ -21,12 +21,12 @@ The scheduled jobs list was last updated June 14, 2026.
 | ponylang-website: verify site builds | 02:00 | [ponylang/ponylang-website](https://github.com/ponylang/ponylang-website) |
 | pony-patterns: verify site builds | 02:00 | [ponylang/pony-patterns](https://github.com/ponylang/pony-patterns) |
 | pony-tutorial: verify site builds | 02:00 | [ponylang/pony-tutorial](https://github.com/ponylang/pony-tutorial) |
-| ponyc: stress test (Linux TCP open/close) | 05:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (Linux ubench) | 05:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (Windows TCP open/close) | 05:45 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (Windows ubench) | 05:45 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (macOS TCP open/close) | 06:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (macOS ubench) | 06:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Linux TCP open/close) | 07:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (macOS TCP open/close) | 13:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Windows TCP open/close) | 17:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Linux ubench) | 18:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (macOS ubench) | 21:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Windows ubench) | 23:15 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | lori: stress tests | 06:30 | [ponylang/lori](https://github.com/ponylang/lori) |
 | ponyc: test with latest tools | 12:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | pony-sync-helper: post good first issues | 14:00 Mon | [ponylang/pony-sync-helper](https://github.com/ponylang/pony-sync-helper) |


### PR DESCRIPTION
ponyc is moving its stress tests from three same-time bursts (05:30/05:45/06:00) to a staggered, near-continuous loop in ponylang/ponyc#5559. This updates the scheduled-jobs table to the new spread-out start times (07:00 through 23:15) and bumps the "last updated" date.