### PR TITLE
Note the Windows version floor on the supported-platforms page

### DIFF
--- a/docs/learn/installing-pony.md
+++ b/docs/learn/installing-pony.md
@@ -20,6 +20,8 @@ The easiest way to install Pony is through [ponyup](https://github.com/ponylang/
 * ✗ **Unsupported** — no support
 * — **Not applicable** — combination doesn't exist
 
+On Windows, the minimum supported version is **Windows 11 / Windows Server 2022** (build 20348). Pony's networking uses an OS readiness API introduced in that build; earlier versions, including Windows 10, are unsupported.
+
 Platforms marked 🧪 Tested have no prebuilt binary; you'll need to [build ponyc from source](https://github.com/ponylang/ponyc/blob/main/BUILD.md).
 
 ## Install ponyup


### PR DESCRIPTION
Adds a note to the supported-platforms section recording that the minimum supported Windows version is Windows 11 / Windows Server 2022 (build 20348), and that Windows 10 is unsupported.

The OS×CPU matrix is unchanged (Windows is still released for amd64/arm64); this only adds the version-floor prose, mirroring the note added to the ponyc README.

**Do not merge before ponylang/ponyc#5556.** That PR is what actually moves Windows networking to the readiness API (`ProcessSocketNotifications`) and drops Windows 10. Until it ships, this page would announce a floor that isn't in effect, so this should merge only after (or together with) ponyc#5556.