### PR TITLE
Add Windows systematic generative stress test to the schedule

### DIFF
--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -26,6 +26,7 @@ The scheduled jobs list was last updated June 26, 2026.
 | ponyc: stress test (Windows TCP open/close) | 17:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (macOS generative, systematic) | 08:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Linux musl generative, systematic) | 14:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Windows generative, systematic) | 11:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Linux musl generative, normal) | 18:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (macOS generative, normal) | 21:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Windows generative, normal) | 23:15 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |


### PR DESCRIPTION
ponylang/ponyc#5579 added a Windows systematic generative stress test that runs daily at 11:00 UTC. This adds it to the scheduled-jobs table, alongside the existing macOS (08:00) and Linux (14:00) systematic generative entries.