### PR TITLE
Move glibc to Tier 1 and musl to Tier 2 in the CI docs

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -6,11 +6,11 @@ ponyc organizes its CI into three tiers to balance fast feedback against compreh
 
 Tier 1 jobs run on every non-draft PR. These are the primary platforms where we want fast feedback and where regressions are most likely to be caught. A PR must pass all Tier 1 jobs before merging.
 
-- x86-64 Linux (musl)
+- x86-64 Linux (glibc)
 - arm64 macOS
 - x86-64 Windows
 
-For x86-64 Linux, the per-PR job builds against musl; the glibc build runs in Tier 2.
+For x86-64 Linux, the per-PR job builds against glibc; the musl build runs in Tier 2.
 
 Tier 1 jobs are defined in the [pr](https://github.com/ponylang/ponyc/blob/main/.github/workflows/pr.yml) workflow.
 
@@ -18,7 +18,8 @@ Tier 1 jobs are defined in the [pr](https://github.com/ponylang/ponyc/blob/main/
 
 Tier 2 covers the platforms we ship release binaries for that aren't already gated on every PR by Tier 1. They run on a daily schedule (1 AM UTC) rather than on every PR, gated on whether there were commits in the last 24 hours.
 
-- x86-64 Linux glibc (deb and rpm)
+- x86-64 Linux musl
+- x86-64 Linux glibc (rpm)
 - arm64 Linux (glibc and musl)
 - x86-64 macOS
 - arm64 Windows

--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -2,7 +2,7 @@
 
 Across a variety of repositories, we have a number of scheduled CI jobs. This document is an attempt to give a broad overview of what exists and when they run. Please note, this list is not guaranteed to be up-to-date and you should check various repos for final confirmation.
 
-The scheduled jobs list was last updated June 26, 2026.
+The scheduled jobs list was last updated June 27, 2026.
 
 <!-- markdownlint-disable -->
 
@@ -25,9 +25,9 @@ The scheduled jobs list was last updated June 26, 2026.
 | ponyc: stress test (macOS TCP open/close) | 13:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Windows TCP open/close) | 17:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (macOS generative, systematic) | 08:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (Linux musl generative, systematic) | 14:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Linux glibc generative, systematic) | 14:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Windows generative, systematic) | 11:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (Linux musl generative, normal) | 18:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Linux glibc generative, normal) | 18:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (macOS generative, normal) | 21:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Windows generative, normal) | 23:15 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | lori: stress tests | 06:30 | [ponylang/lori](https://github.com/ponylang/lori) |


### PR DESCRIPTION
Keeps the CI tier docs in sync with ponyc's CI change: the per-PR x86-64 Linux job now builds against glibc (Ubuntu 26.04), musl moves to the nightly Tier 2, and the two single-Linux generative stress tests run on glibc. Updates the Tier 1/Tier 2 lists in `ponyc-ci-tiers.md` and the two generative-Linux rows in `scheduled-jobs.md`.