### PR TITLE
Update Tier 3 FreeBSD to 15.1 in the CI docs

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -33,7 +33,7 @@ Tier 3 covers platforms we test but don't ship release binaries for. They run on
 - arm Linux (cross-compiled)
 - armhf Linux (cross-compiled)
 - x86-64 FreeBSD 14.3
-- x86-64 FreeBSD 15.0
+- x86-64 FreeBSD 15.1
 - x86-64 OpenBSD 7.9
 - x86-64 DragonFly BSD 6.4.2
 


### PR DESCRIPTION
ponyc#5555 moved tier-3 FreeBSD 15 testing to 15.1, but the CI tiers doc still listed 15.0.