### PR TITLE
Drop FreeBSD 14.3 from the ponyc tier-3 CI list

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -33,7 +33,6 @@ Tier 3 covers platforms we test but don't ship release binaries for. They run on
 - `riscv64` Linux (cross-compiled)
 - arm Linux (cross-compiled)
 - armhf Linux (cross-compiled)
-- x86-64 FreeBSD 14.3
 - x86-64 FreeBSD 15.1
 - x86-64 OpenBSD 7.9
 - x86-64 DragonFly BSD 6.4.2


### PR DESCRIPTION
ponyc has stopped testing FreeBSD 14.3 and now tests only FreeBSD 15.1. Remove 14.3 from the tier-3 platform list on the CI tiers page to match.