### PR TITLE
Update macOS and Windows generative normal stress cron times

### DIFF
--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -2,7 +2,7 @@
 
 Across a variety of repositories, we have a number of scheduled CI jobs. This document is an attempt to give a broad overview of what exists and when they run. Please note, this list is not guaranteed to be up-to-date and you should check various repos for final confirmation.
 
-The scheduled jobs list was last updated June 27, 2026.
+The scheduled jobs list was last updated June 28, 2026.
 
 <!-- markdownlint-disable -->
 
@@ -28,8 +28,8 @@ The scheduled jobs list was last updated June 27, 2026.
 | ponyc: stress test (Linux glibc generative, systematic) | 14:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Windows generative, systematic) | 11:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: stress test (Linux glibc generative, normal) | 18:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (macOS generative, normal) | 21:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| ponyc: stress test (Windows generative, normal) | 23:15 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (macOS generative, normal) | 22:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Windows generative, normal) | 02:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | lori: stress tests | 06:30 | [ponylang/lori](https://github.com/ponylang/lori) |
 | ponyc: test with latest tools | 12:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | pony-sync-helper: post good first issues | 14:00 Mon | [ponylang/pony-sync-helper](https://github.com/ponylang/pony-sync-helper) |


### PR DESCRIPTION
ponyc re-spaced two of its normal-mode generative stress jobs — macOS 21:30 → 22:00 and Windows 23:15 → 02:00 — to give the longer runs room before the next scheduled job. This list mirrors the real schedule, so match them.

These times go live when the ponyc change that re-spaces them ships, so this should land alongside or after that change rather than before it.