### PR TITLE
Frame systematic testing as a tool for runtime developers

### DIFF
--- a/docs/use/compiler.md
+++ b/docs/use/compiler.md
@@ -10,7 +10,7 @@ Compiled Pony programs accept `--pony*` command-line flags for tuning scheduler 
 
 ## Custom ponyc Builds
 
-ponyc can be built from source with instrumentation options for debugging: Valgrind annotations, sanitizers (address, thread, undefined behavior), DTrace/SystemTap probes, and systematic testing for concurrency bugs.
+ponyc can be built from source with instrumentation options for debugging: Valgrind annotations, sanitizers (address, thread, undefined behavior), DTrace/SystemTap probes, and systematic testing for the runtime's own concurrency bugs.
 
 - [Custom ponyc Builds for Debugging](compiler/custom-ponyc-builds.md)
 

--- a/docs/use/compiler/custom-ponyc-builds.md
+++ b/docs/use/compiler/custom-ponyc-builds.md
@@ -210,7 +210,9 @@ For details on tracing options and usage, see [Tracing Pony Programs](../debuggi
 
 ## Systematic Testing
 
-Systematic testing replaces the Pony scheduler with a deterministic, single-threaded scheduler that explores different actor interleaving orders. This is useful for reproducing concurrency bugs that are otherwise non-deterministic.
+Systematic testing replaces the Pony scheduler with a deterministic, single-threaded scheduler that explores different actor interleaving orders. It's a tool for working on the runtime itself: when a runtime change has a bug that only shows up under some scheduler interleaving, systematic testing lets you replay that interleaving from a seed.
+
+A program run under systematic testing has to be deterministic, and keeping it that way is on you. The runtime removes its own source of nondeterminism: it turns off the ASIO thread entirely, the thread that does asynchronous I/O whose timing a seed can't control. So any asynchronous I/O — a socket, standard input, a spawned process, a signal handler, a timer — aborts the program. Ordinary output and synchronous file I/O still work. But that's only the runtime's nondeterminism. Your own code can still make a run you can't replay — reading the wall clock, say — and unlike I/O, that won't abort.
 
 Systematic testing requires two options together:
 
@@ -223,7 +225,7 @@ The `scheduler_scaling_pthreads` option is required because systematic testing n
 
 ### Seed-Based Replay
 
-When a systematic testing build runs, it uses a random seed to determine the interleaving order. If a run triggers a bug, the runtime prints the seed and a rerun command to stderr. You can replay the exact same interleaving:
+When a systematic testing build runs, it uses a random seed to determine the interleaving order. The runtime prints the seed and a rerun command to stderr at the start of every run. When a run triggers a bug, replay that seed to reproduce the exact same interleaving:
 
 ```bash
 ./my-program --ponysystematictestingseed 12345

--- a/docs/use/debugging.md
+++ b/docs/use/debugging.md
@@ -24,4 +24,4 @@ Interested in tracing the execution of a Pony program? Checkout ["Tracing Pony P
 
 ## Custom ponyc Builds
 
-ponyc can be built from source with instrumentation options for debugging: Valgrind annotations, sanitizers (address, thread, undefined behavior), DTrace/SystemTap probes, and systematic testing for concurrency bugs. See [Custom ponyc Builds for Debugging](compiler/custom-ponyc-builds.md).
+ponyc can be built from source with instrumentation options for debugging: Valgrind annotations, sanitizers (address, thread, undefined behavior), DTrace/SystemTap probes, and systematic testing for the runtime's own concurrency bugs. See [Custom ponyc Builds for Debugging](compiler/custom-ponyc-builds.md).


### PR DESCRIPTION
Systematic testing is for people working on the ponyc runtime, not for reproducing bugs in ordinary Pony programs. The page framed it as the latter and went deep on I/O detail that doesn't matter to that reader. It also now turns off the ASIO thread entirely (ponylang/ponyc#5647), so a program run under it must be deterministic and can't do asynchronous I/O.

Reframe the section around who it's for and what that means, and fix the two other pages that glossed it as a user-facing debugging tool.

Companion to ponylang/ponyc#5647.
