### PR TITLE
Fix Helix pony-lsp config to pass no arguments

### DIFF
--- a/docs/use/pony-lsp.md
+++ b/docs/use/pony-lsp.md
@@ -66,7 +66,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [language-server.pony-lsp]
 command = "pony-lsp"
-args = [""]
+args = []
 ```
 
 #### Project-Specific Defines


### PR DESCRIPTION
The Helix example configured `args = [""]`, which passes `pony-lsp` a single empty-string argument. That was harmless while `pony-lsp` ignored all arguments, but as of [ponyc #5668](https://github.com/ponylang/ponyc/pull/5668) `pony-lsp` parses its arguments and rejects anything it doesn't recognize. The empty-string argument now stops the language server from starting.

Setting `args = []` passes no arguments, which is what the Helix setup needs.

Anyone whose `languages.toml` still has `args = [""]` after upgrading `pony-lsp` will need to make this same change.