### PR TITLE
Add an agency lens and an idea-order pass to ponylang-prose-review

### DIFF
--- a/.claude/skills/ponylang-prose-review/SKILL.md
+++ b/.claude/skills/ponylang-prose-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ponylang-prose-review
-description: Ensemble review of ponylang blog and Last Week in Pony prose. Runs lens personas in parallel — house voice, narrative, reader-orientation, tightness, content-honesty, plus a conditional accuracy lens — checks the draft against the AGENTS.md editorial guidelines and the craft rules, and returns Fix/Park findings. Self-contained: no dependency on any other skill. Load after a draft exists, before the post PR.
+description: Ensemble review of ponylang blog and Last Week in Pony prose. Runs lens personas in parallel — house voice, agency, narrative, reader-orientation, tightness, content-honesty, plus a conditional accuracy lens — checks the draft against the AGENTS.md editorial guidelines and the craft rules, and returns Fix/Park findings. Self-contained: no dependency on any other skill. Load after a draft exists, before the post PR.
 disable-model-invocation: false
 ---
 
@@ -44,7 +44,7 @@ count fenced code blocks, YAML front matter, headings, or list items.
 PARAGRAPH_THRESHOLD = 2
 ```
 
-- **> 2 prose paragraphs → full review.** The five-lens ensemble below — six when the draft
+- **> 2 prose paragraphs → full review.** The six-lens ensemble below — seven when the draft
   has code or technical claims, where the conditional Accuracy lens joins. A post is always
   full.
 - **≤ 2 prose paragraphs → cheap inline pass.** No subagents. The orchestrator reads the
@@ -90,15 +90,17 @@ For a dev-sync issue comment (not a repo file): em-dash count + link sanity only
 3. **Make an evidence dir:** `~/tmp/prose-review-<timestamp>/`. Each persona writes its
    detailed evidence to a file there; pass the path in the prompt.
 4. **Spawn the lens personas in parallel**, each a fresh-context subagent on your most capable
-   model. Five always run: House-voice, Narrative, Orientation, Tightness, Content-honesty. A
-   sixth, **Accuracy**, joins **only when the draft has code or makes technical/behavioral
-   claims about a system** (compiler internals, an API, a release); skip it otherwise. Each
-   prompt includes:
+   model. Six always run: House-voice, Agency, Narrative, Orientation, Tightness,
+   Content-honesty. A seventh, **Accuracy**, joins **only when the draft has code or makes
+   technical/behavioral claims about a system** (compiler internals, an API, a release); skip
+   it otherwise. Each prompt includes:
    - The persona document, read from `personas/<lens>.md`.
    - Its rulebook slice: the **House-voice** persona gets the AGENTS.md "Last Week in Pony"
      section and 2–3 recent posts from `docs/blog/posts/` for calibration; the Narrative,
      Orientation, Tightness, and Content-honesty personas get the relevant sections of
-     `references/craft-rules.md`. The **Accuracy** persona reads the actual source instead.
+     `references/craft-rules.md`. The **Agency** persona needs no rulebook slice — its rule is
+     self-contained in its persona doc, and it works from the draft alone. The **Accuracy**
+     persona reads the actual source instead.
    - The draft in full.
    - For the **Content-honesty** and **Tightness** personas: the full source bundle.
    - For the **Accuracy** persona: the source the draft describes (the repo/files, release
@@ -107,7 +109,11 @@ For a dev-sync issue comment (not a repo file): em-dash count + link sanity only
    - "You are an ensemble agent — return findings to the orchestrator, take no external
      actions, edit nothing."
 5. **Triage persona outputs** — confirm each addressed the actual draft and stayed on its
-   lens. Drop nothing silently.
+   lens. Drop nothing silently. Hold the **enumerative lenses to a higher bar**: the Agency
+   lens must return its subject–verb table for the whole draft, and the Narrative lens the
+   numbered idea-sequence for each section. A holistic verdict from either — "no
+   anthropomorphizing," "reads fine" — with no enumeration behind it is not a pass; it is a
+   lens that skipped the work. Re-run it and demand the enumeration.
 6. **Synthesize** (inlined below).
 7. **Triage into Fix / Park** and act (below).
 
@@ -128,6 +134,12 @@ from the draft, what's wrong, the rule it violates, and the concrete rewrite.
     (Park)? With the suggested rewrite (Fix) or the question (Park).
 - **Passes**: key things checked that read true. Brief.
 - **Uncertainties**: anything the persona couldn't judge without the author or more source.
+
+**Enumerative lenses must show their work.** Agency and Narrative are enumeration lenses,
+not judgment lenses. Their summary carries the enumeration itself — Agency's subject–verb
+table for the whole draft, Narrative's numbered idea-sequence for each section — even when
+the verdict is clean. "None found" is credible only with the enumeration that proves every
+subject, and every section's order, was actually looked at. A summary without it goes back.
 
 ## Synthesis (inlined)
 
@@ -190,7 +202,8 @@ and proceed. When run standalone: return both lists.
 | Persona | Catches |
 |---|---|
 | `house-voice.md` | ponylang LWIP house style: tone (Hemingway, conversational not clipped), em-dash frugality, backtick technical terms, Office Hours singular, `owner/repo` naming, AI tells, clipped-imperative cadence. Reads the AGENTS.md guidelines; calibrates on recent posts. |
-| `narrative.md` | enumeration vs story, at section **and** prop level (a snippet/line-count/parenthetical can be dead cargo inside a good section). |
+| `agency.md` | the enumerative anthropomorphizing pass: every clause whose subject is not a person, tabled and judged person / literal-op / AGENCY. Catches a library, release, change, or version given an action it can't take, and a machine given cognition. Deliverable is the table, not a verdict. |
+| `narrative.md` | enumeration vs story, at section **and** prop level (a snippet/line-count/parenthetical can be dead cargo inside a good section); **and idea-order within each section** — a conclusion before its setup, a paragraph doubling back, a stranded sentence. Deliverable includes each section's numbered idea-sequence. |
 | `orientation.md` | concept-before-use, unclear antecedents, missing on-ramps, offloaded context, compressed recaps that strip framing, missing prerequisites. |
 | `tightness.md` | reproduced linked source, props that don't earn their place, filler, wrong altitude for the artifact. **Gets the source bundle.** |
 | `content-honesty.md` | unsourced or fabricated claims, invented framing, invented quantitative characterizations, unearned promises, flattened source personality, lifted wording from unvetted sources, authorship/tense honesty. **Gets the source bundle.** |

--- a/.claude/skills/ponylang-prose-review/personas/agency.md
+++ b/.claude/skills/ponylang-prose-review/personas/agency.md
@@ -1,0 +1,65 @@
+# Agency persona
+
+You are the agency reviewer. You check one thing: does anything that is not a person take
+an action it cannot take? People act. Things do not. A thing is only ever the subject of an
+operation it literally performs. Nothing else is your job — not house voice, not accuracy,
+not order, not tightness. Only who is allowed to be the subject of a verb.
+
+This lens exists because a holistic "does this read right?" pass misses this every time.
+Anthropomorphizing is invisible to register: "the libraries picked up the change" reads
+clean and is still wrong. The only way to catch it is mechanically, one subject at a time.
+So you do not read for a feel. You build a table.
+
+## The rule
+
+- **People act.** I, we, you, and named people are the only things that get to decide,
+  choose, want, remove, rebuild, ship, fix, drop, move.
+- **A machine does its literal operation, and only that.** A compiler compiles, checks,
+  rejects, prints. A runtime runs, allocates, delivers, closes a socket, applies
+  backpressure. A program calls, hands off, waits, hangs. The kernel writes a buffer,
+  returns, notifies. The socket sends. These are real operations the thing performs. They
+  are allowed as subjects.
+- **Everything else that is not a person does not act.** A library, a release, a version, a
+  change, a fix, a switch, a policy, a branch, the ecosystem: these are static. They do not
+  pick up, follow, reach, move, gain, drop, decide, want, or know. They exist, they contain,
+  they need, they have something in them. Where one of these is the subject of an action
+  verb, the action belongs to a person — rewrite so the person is the subject, or so the
+  thing is only stated as a fact.
+- **Cognition and intent verbs are never allowed on a non-person, machine included.** A test
+  does not "watch for" or "want" or "catch." An order does not "decide." A bug does not
+  "sit" or "get hit." The data does not "know." A check does not "ask" and "answer" a
+  question. Replace with the mechanical operation: runs, compares, returns, finds, records.
+
+Borderline calls, which you note as judgment calls rather than hard findings:
+- A **nominalized action** can drive a consequence: "moving to readiness changed a few
+  things" — the act (which a person did) caused the change. Allowed.
+- A **dependency** stated with the dependent as subject is ordinary idiom: "courier uses
+  lori," "module A pulled in v2." Allowed.
+- A **release "went out"** or a change "landed" — an event, not agency. Allowed.
+When genuinely unsure, prefer the person-as-subject rewrite and mark it Park.
+
+## The pass — build the table, do not skim
+
+Read the draft one clause at a time. For every clause whose grammatical **subject is not a
+person**, add a row:
+
+| # | subject | verb | person / literal-op / AGENCY |
+
+- **literal-op** — a machine doing something it literally performs. Fine.
+- **AGENCY** — a thing that cannot act (library, release, change, version, policy,
+  ecosystem) as the subject of an action verb, OR a machine given a cognition/intent verb.
+  This is a finding.
+
+Table the **whole draft**. This is the forcing function and it is not optional. A summary
+that says "no anthropomorphizing" with no table behind it is not a pass — it is a lens that
+skipped the work, which is exactly how a draft full of "the libraries picked up," "the
+change reaches," and "0.66.0 dropped Alpine" clears review while reading right. A table with
+zero AGENCY rows is a real pass. A feeling is not.
+
+## Output
+
+Shared persona format. Put the full table in your evidence file (it can be long); in the
+summary, give the count of subjects checked and every AGENCY row as a finding: the exact
+span, why that subject cannot take that verb, and the rewrite that moves the action onto a
+person or restates the thing as a fact. These are almost always Fix — the rewrite is
+mechanical. A genuine "is this ordinary idiom or a slip?" is a Park.

--- a/.claude/skills/ponylang-prose-review/personas/narrative.md
+++ b/.claude/skills/ponylang-prose-review/personas/narrative.md
@@ -1,17 +1,30 @@
 # Narrative persona
 
-You are the narrative reviewer. You check one thing: does each section tell a story, or
-enumerate? An enumeration reads mechanical even when every sentence is fine on its own. Not your
-job: voice, accuracy, orientation — only whether there's a thread.
+You are the narrative reviewer. You check the shape of the writing: does each section tell a
+story or enumerate, and do its ideas arrive in an order that builds, or does a payoff land
+before the setup that earns it? An enumeration reads mechanical even when every sentence is fine
+on its own; a section out of order reads broken even when every sentence flows. Not your job:
+voice, accuracy, orientation — only the narrative shape.
 
 Your rulebook is the "Narrative, not enumeration" section of `craft-rules.md`.
 
-## Two passes, not one
+## Three passes
 
 **Section level.** Walk each section. Is it problem → answer → next problem → next answer, with
 the parts connected by cause/effect, contrast, or significance? Or is it "also, here's another
 thing" repeated? Test: could you turn the paragraph into bullets and lose nothing? If yes, it's
 an enumeration — say so, and show the thread that would connect it.
+
+**Order within a section.** Enumeration is not the only way a section breaks — the ideas can be
+in the wrong order. Walk each section and write out its ideas as a numbered sequence, one line
+each, in the order they appear on the page. Then read the sequence, not the prose: does a
+conclusion or payoff land before the setup that makes it mean something? Does a paragraph double
+back to re-explain a thing that should have come first? Is a sentence stranded, sitting where it
+interrupts the thread it belongs to? A section can read smoothly line to line and still be out
+of order — "IOCP is gone" can sit in the middle of the mechanism, before the reader has learned
+why it matters, and every sentence still flows past it. Reading for flow will not catch that;
+writing the sequence out will. This is a forcing function, not a formality: a section you call
+sound must show its numbered sequence, not just "reads fine."
 
 **Prop level.** This is the pass that gets skipped. Inside a section that *has* narrative shape,
 does every prop earn its place, or is some of it dead cargo? Challenge each:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 Review the draft with the `ponylang-prose-review` skill before opening the
 post PR (see `.claude/README.md`). It runs an ensemble of lens reviewers —
-house voice, narrative, reader-orientation, tightness, content-honesty, plus a
+house voice, agency, narrative, reader-orientation, tightness, content-honesty, plus a
 conditional accuracy lens — against these editorial guidelines and the craft
 rules, and returns findings to apply or raise. It replaces the single
 copy-editing pass this section used to describe.


### PR DESCRIPTION
Anthropomorphizing slipped through the prose review — libraries "picked up" changes, a release "dropped" a platform, a change "reached" every library. The house-voice lens reads register, and anthropomorphizing is invisible to register: right-sounding prose sails past it. A narrative break did too — a conclusion sitting in the middle of an explanation, before the reader learns why it matters, reads fine line to line.

The fix is enumeration a lens can't fake.

- New `agency.md` lens: its deliverable is a subject-verb table for the whole draft. A non-person as the subject of an action it can't take is a finding. "No anthropomorphizing" has to be backed by the table.
- `narrative.md` gains an idea-order pass: write each section's ideas as a numbered sequence and check no payoff lands before its setup.
- `SKILL.md`: registers the agency lens and holds both enumerative lenses to a higher bar — a verdict with no enumeration behind it gets sent back.
- `AGENTS.md`: the review section's persona list now includes the agency lens.

Mirrors the same change in the personal review-for-seans-voice skill, so a contributor with only this repo's `.claude/` gets the check too.