### PR TITLE
Update build docs for ponyc's CMake migration

### DIFF
--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -4,56 +4,69 @@ This page covers building ponyc from source for development and contribution wor
 
 ## Build Workflow
 
+The build system is CMake. Presets in `CMakePresets.json` set up the build directories, compiler, and flags for you, and a small CMake runner (`lib/build-libs.cmake`) builds the vendored LLVM and support libraries. You run `cmake` and `ctest` directly — there's no wrapper.
+
 Building ponyc from source is a multi-stage process:
 
 ```bash
-make libs              # Build vendored LLVM (one-time, takes hours)
-make configure         # Configure the CMake build directory
-make build             # Compile ponyc and the runtime
-make test              # Run the test suite
-sudo make install      # Install to /usr/local (or use prefix=/foo)
+cmake -P lib/build-libs.cmake          # Build vendored LLVM (one-time, takes hours)
+cmake --preset release                 # Configure the build directory
+cmake --build --preset release         # Compile ponyc and the runtime
+ctest --preset release -L ci-core      # Run the compiler, runtime, and stdlib tests
+sudo cmake --install build/build_release   # Install to /usr/local
 ```
 
-`make libs` only needs to run once. You'll need to rerun it if the vendored LLVM submodule changes or if you run `make distclean`.
-
-To speed up the LLVM build, pass parallel build flags:
+`cmake -P lib/build-libs.cmake` only needs to run once. You'll need to rerun it if the vendored LLVM submodule changes or if you delete the `build` directory. To speed up the LLVM build, pass `-DJOBS` (LLVM is memory-hungry, so keep it modest):
 
 ```bash
-make libs build_flags="-j6"
+cmake -DJOBS=6 -P lib/build-libs.cmake
+```
+
+The compiled `ponyc` lands in `build/release`. The CMake build directory itself is `build/build_release` — that's the path `cmake --install` takes, not `build/release`. To install somewhere other than `/usr/local`, pass `--prefix`:
+
+```bash
+sudo cmake --install build/build_release --prefix /foo
 ```
 
 To clean up:
 
-- `make clean` — removes the ponyc build artifacts but keeps the LLVM libraries.
-- `make distclean` — deletes the entire `build` directory, including LLVM. You'll need to rerun `make libs` after this.
+- `rm -rf build/build_release build/release` — removes the ponyc build but keeps the LLVM libraries. A debug or architecture build uses the matching directory names (`build/build_debug` and `build/debug`, and so on).
+- `rm -rf build` — deletes the entire `build` directory, including LLVM. You'll need to rerun `cmake -P lib/build-libs.cmake` after this.
 
 ## Build Configuration
 
-The main configuration variables are:
-
-| Variable | Default | Description |
-|---|---|---|
-| `config` | `release` | Build type: `release` or `debug` |
-| `arch` | `native` | CPU architecture |
-| `tune` | `generic` | CPU tuning |
-| `build_flags` | `-j2` | Flags passed to the underlying build tool |
-
-Configuration is set at the `make configure` step and carried through to `make build`:
+Each preset configures its own out-of-source build directory. The two you'll use most are `release` and `debug` (both native architecture). Pick one at the configure step and use the matching preset to build and test:
 
 ```bash
-make configure config=debug
-make build config=debug
+cmake --preset debug
+cmake --build --preset debug
+ctest --preset debug -L ci-core
+```
+
+A debug build lands in `build/debug`, with its CMake build directory at `build/build_debug`.
+
+There are also architecture-specific preset families — `x86-64`, `armv8`, and `armv8-a` — each providing a runnable `-debug` and `-release` variant (for example, `armv8-a-release`; the bare family names aren't runnable on their own). For a CPU without a preset, start from the `release` or `debug` preset and set `PONY_ARCH` and the compiler flags yourself:
+
+```bash
+cmake --preset release -DPONY_ARCH=arm7 -DCMAKE_C_FLAGS="-march=arm7 -mtune=generic" -DCMAKE_CXX_FLAGS="-march=arm7 -mtune=generic"
+cmake --build --preset release
+```
+
+To parallelize the ponyc build itself, pass `--parallel` to the build step:
+
+```bash
+cmake --build --preset release --parallel 6
 ```
 
 ## Compiler Selection
 
-The build system defaults to clang if it's available. To use GCC instead:
+The presets default to clang. To use GCC instead, override the compiler at the configure step:
 
 ```bash
-make configure CC=gcc CXX=g++
+cmake --preset release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
 ```
 
-The C and C++ compilers must be a matching pair. The build will error if you mix clang with g++ or gcc with clang++.
+You don't need to rebuild the LLVM libraries to switch the ponyc compiler this way — the libraries built with `cmake -P lib/build-libs.cmake` work with either. (On the platforms that must build with GCC — 32-bit Raspbian and DragonFly BSD — you build the libraries with GCC as well; see those sections below.) Use a matching pair — both clang or both gcc — rather than mixing a C compiler from one toolchain with a C++ compiler from another.
 
 ## Performance Options
 
@@ -62,8 +75,8 @@ The C and C++ compilers must be a matching pair. The build will error if you mix
 LTO provides a performance improvement and is worth enabling if you're building ponyc for regular use. It's off by default because it requires clang as the linker — with other linkers, LTO has occasionally produced incorrect binaries. On macOS, an XCode upgrade will require rebuilding ponyc when LTO is enabled.
 
 ```bash
-make configure lto=yes
-make build
+cmake --preset release -DPONY_USE_LTO=true
+cmake --build --preset release
 ```
 
 ### Runtime Bitcode
@@ -71,8 +84,8 @@ make build
 With clang, you can build the Pony runtime as LLVM bitcode. This enables cross-module optimizations between your Pony code and the runtime — essentially "super LTO" for the runtime. Optimization times can be significantly longer.
 
 ```bash
-make configure runtime-bitcode=yes
-make build
+cmake --preset release -DPONY_RUNTIME_BITCODE=true
+cmake --build --preset release
 ```
 
 Then compile programs with:
@@ -86,10 +99,11 @@ ponyc --runtimebc
 
 ## Instrumentation
 
-The `use=` option enables various instrumentation features. It is only valid with `make configure`. Multiple options can be combined with commas:
+The `PONY_USES` option enables various instrumentation features. It is set at the configure step. Multiple options can be combined with commas:
 
 ```bash
-make configure use=address_sanitizer,undefined_behavior_sanitizer
+cmake --preset release -DPONY_USES=address_sanitizer,undefined_behavior_sanitizer
+cmake --build --preset release
 ```
 
 The available options:
@@ -113,14 +127,14 @@ The available options:
 For detailed usage of valgrind, sanitizers, DTrace, and systematic testing, see [Custom ponyc Builds](../../use/compiler/custom-ponyc-builds.md).
 
 !!! warning "Some options aren't available on OpenBSD or DragonFly BSD"
-    On OpenBSD, `valgrind`, `address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`, `coverage`, and `dtrace` depend on a runtime, headers, or tooling that OpenBSD doesn't ship, so they can't be built there; `gmake configure` rejects them with an explanatory error instead of failing partway through the build. On DragonFly BSD, the three sanitizers (`address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`) can't be built because its `gcc13` toolchain ships no sanitizer runtime, and `dtrace` can't be built because DragonFly ships no DTrace-compatible probe-generation tool; as on OpenBSD, `gmake configure` rejects these four with an explanatory error instead of failing partway through the build. `use=valgrind` doesn't work there either: it builds, but DragonFly ships a Valgrind too old to run a Pony program ([ponyc#5435](https://github.com/ponylang/ponyc/issues/5435)). See ponyc's BUILD.md for the details.
+    On OpenBSD, `valgrind`, `address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`, `coverage`, and `dtrace` depend on a runtime, headers, or tooling that OpenBSD doesn't ship, so they can't be built there; configuring rejects them with an explanatory error instead of failing partway through the build. On DragonFly BSD, the three sanitizers (`address_sanitizer`, `thread_sanitizer`, `undefined_behavior_sanitizer`) can't be built because its `gcc13` toolchain ships no sanitizer runtime, and `dtrace` can't be built because DragonFly ships no DTrace-compatible probe-generation tool; as on OpenBSD, configuring rejects these four with an explanatory error instead of failing partway through the build. `valgrind` doesn't work there either: it builds, but DragonFly ships a Valgrind too old to run a Pony program ([ponyc#5435](https://github.com/ponylang/ponyc/issues/5435)). See ponyc's BUILD.md for the details.
 
 ## IDE Integration
 
-To generate a `compile_commands.json` for clangd and other LSP tools:
+To generate a `compile_commands.json` for clangd and other LSP tools, configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`:
 
 ```bash
-make configure CMAKE_FLAGS='-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
+cmake --preset release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 ```
 
 Then symlink the generated file into the project root:
@@ -135,48 +149,52 @@ Replace `build_release` with `build_debug` if you're using a debug configuration
 
 ### FreeBSD, OpenBSD, and DragonFly BSD
 
-Use `gmake` instead of `make` for all build commands. On OpenBSD, use `doas` instead of `sudo` for installation.
+On OpenBSD, use `doas` instead of `sudo` for installation. All three BSDs need `gmake` installed as a package (CMake and the LLVM build shell out to it), but you drive the build with `cmake` and `ctest` directly, the same as everywhere else.
 
-On DragonFly BSD, the base compiler (GCC 8.3) cannot build the vendored LLVM. Install `gcc13` from packages and pass `CC=/usr/local/bin/gcc13 CXX=/usr/local/bin/g++13` to all `gmake` commands. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#dragonfly) for full instructions.
+On DragonFly BSD, the base compiler (GCC 8.3) cannot build the vendored LLVM. Install `gcc13` from packages and pass `-DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13` to `cmake -P lib/build-libs.cmake`, and `-DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13` to the configure step. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#dragonfly) for full instructions.
 
 ### 32-bit Raspbian
 
-Only GCC works on 32-bit Raspbian — clang is not supported. You also need to override the `tune` option:
+Only GCC works on 32-bit Raspbian — clang is not supported. You also need to build for native CPU tuning:
 
 ```bash
-make libs
-make configure tune=native
-make build
+cmake -DCC=gcc -DCXX=g++ -P lib/build-libs.cmake
+cmake --preset release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-march=native -mtune=native" -DCMAKE_CXX_FLAGS="-march=native -mtune=native"
+cmake --build --preset release
+sudo cmake --install build/build_release
 ```
 
 ### 64-bit Raspbian
 
-You need to pass `pic_flag=-fPIC` to both the `libs` and `configure` steps, and override the `arch`. The `arch` override is also needed at install time:
+Build for the `armv8-a` architecture, and pass the position-independent-code flag to both the libs step (`-DPIC`) and the configure step (`-DPONY_PIC_FLAG`). The install reads the arch-specific build directory:
 
 ```bash
-make libs pic_flag=-fPIC
-make configure arch=armv8-a pic_flag=-fPIC
-make build
-sudo make install arch=armv8-a
+cmake -DPIC=-fPIC -P lib/build-libs.cmake
+cmake --preset armv8-a-release -DPONY_PIC_FLAG=-fPIC
+cmake --build --preset armv8-a-release
+sudo cmake --install build/build_armv8-a-release
 ```
 
 ### Asahi (M1 Linux)
 
-Override the `arch` option:
+Build for the `armv8` architecture with its preset:
 
 ```bash
-make libs
-make configure arch=armv8
-make build
+cmake -P lib/build-libs.cmake
+cmake --preset armv8-release
+cmake --build --preset armv8-release
+sudo cmake --install build/build_armv8-release
 ```
 
 ## Debugging Tests
 
-The `usedebugger` variable wraps test binaries in a debugger that captures crash information — backtraces, register state, and local variables. This is useful for investigating test failures:
+Setting the `PONY_TEST_DEBUGGER` environment variable wraps test binaries in a debugger that captures crash information — backtraces, register state, and local variables. This is useful for investigating test failures. The `.ci-scripts/test-debugger.sh` helper prints the debugger command for you; capture it into `PONY_TEST_DEBUGGER`, then run the tests. `ctest` runs the already-built tests without building them, so configure and build the preset first:
 
 ```bash
-make test usedebugger=lldb
-make test usedebugger=gdb
+cmake --preset debug
+cmake --build --preset debug
+export PONY_TEST_DEBUGGER="$(.ci-scripts/test-debugger.sh lldb)"
+ctest --preset debug -L ci-core
 ```
 
-When a test crashes, the debugger runs automatically and prints diagnostic output before exiting with a non-zero status.
+Pass `gdb` instead of `lldb` to use gdb. When a test crashes, the debugger runs automatically and prints diagnostic output before exiting with a non-zero status.

--- a/docs/contribute/developer-resources/arm-development-with-rpi-4.md
+++ b/docs/contribute/developer-resources/arm-development-with-rpi-4.md
@@ -77,14 +77,16 @@ Things you might want to do that are left to an exercise to the user:
 
 ## Building pony
 
-To build pony after you've cloned the source code, you'll follow the directions below. Note, because building with clang isn't currently supported, if you install `clang` you'll need to modify all the command below to build using `gcc` as the Pony build system defaults to using `clang` if it is available. To use `gcc`, you'd prepend `CC=/usr/bin/gcc CXX=/usr/bin/g++` to all the command below.
+These steps are for a 32-bit Raspbian. On a 64-bit Raspbian, follow the [64-bit Raspbian](../compiler/building-ponyc-from-source.md#64-bit-raspbian) section instead — clang works there and you build for the `armv8-a` architecture.
 
-- `make libs build_flags="-j4"`
+To build pony after you've cloned the source code, you'll follow the directions below. Building with `clang` isn't currently supported on 32-bit Arm, and the CMake presets default to `clang`, so you need to point the build at `gcc`. That means `-DCC=/usr/bin/gcc -DCXX=/usr/bin/g++` at the libs step and `-DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++` at the configure step.
+
+- `cmake -DCC=/usr/bin/gcc -DCXX=/usr/bin/g++ -DJOBS=4 -P lib/build-libs.cmake`
 
 note, this will probably take about 3 hours. make sure you aren't logged out of ssh.
 
-- `make configure`
-- `make build -mtune=native`
-- `make test`
+- `cmake --preset release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DCMAKE_C_FLAGS="-march=native -mtune=native" -DCMAKE_CXX_FLAGS="-march=native -mtune=native"`
+- `cmake --build --preset release`
+- `ctest --preset release -L ci-core`
 
 See [Building ponyc from Source](../compiler/building-ponyc-from-source.md) for more information about building ponyc.

--- a/docs/faq/compiling.md
+++ b/docs/faq/compiling.md
@@ -20,11 +20,7 @@ For example:
 ponyc --pic examples/helloworld
 ```
 
-As of Pony 0.17.0, if you are building `ponyc` from source, you can have `--pic` automatically set for you. When building `ponyc`, run the following `make` command and your generated `ponyc` binary will always supply `--pic` without you having to set it.
-
-```bash
-make default_pic=true
-```
+A `ponyc` built from source applies `--pic` by default, so you don't need to set it yourself when using such a compiler.
 
 ## On Windows I get `fatal error LNK1112: module machine type 'x86' conflicts with target machine type 'x64'` {:id="lnk1112"}
 

--- a/docs/use/compiler/custom-ponyc-builds.md
+++ b/docs/use/compiler/custom-ponyc-builds.md
@@ -1,6 +1,6 @@
 # Custom ponyc Builds for Debugging
 
-ponyc supports several build-time options that instrument the compiler and runtime for debugging. These require building ponyc from source with specific flags. All options described here use the Unix/Makefile build system.
+ponyc supports several build-time options that instrument the compiler and runtime for debugging. These require building ponyc from source with specific options. All commands here are for the Unix build.
 
 ## Build Workflow
 
@@ -11,27 +11,27 @@ Every option follows the same pattern:
     ```bash
     git clone https://github.com/ponylang/ponyc.git
     cd ponyc
-    make libs
+    cmake -P lib/build-libs.cmake
     ```
 
 2. Configure with the desired option:
 
     ```bash
-    make configure use=<option>
+    cmake --preset release -DPONY_USES=<option>
     ```
 
 3. Build:
 
     ```bash
-    make build
+    cmake --build --preset release
     ```
 
-The resulting `ponyc` binary is in `build/release/` — or, when you pass `use=` options, a suffixed directory like `build/release-address_sanitizer` that lists the enabled options. Use it in place of your system `ponyc` to compile programs with the instrumentation enabled.
+The resulting `ponyc` binary is in `build/release/` — or, when you enable options with `PONY_USES`, a suffixed directory like `build/release-address_sanitizer` that lists the enabled options. The suffix always lists them in a fixed order set by the build, independent of the order you pass them, so the directory name may not match what you typed. Use it in place of your system `ponyc` to compile programs with the instrumentation enabled.
 
 To combine multiple options, separate them with commas:
 
 ```bash
-make configure use=address_sanitizer,undefined_behavior_sanitizer
+cmake --preset release -DPONY_USES=address_sanitizer,undefined_behavior_sanitizer
 ```
 
 Not all combinations are valid — see the individual sections below for compatibility notes.
@@ -51,8 +51,8 @@ apt-get install valgrind
 Build ponyc with Valgrind support:
 
 ```bash
-make configure use=valgrind
-make build
+cmake --preset release -DPONY_USES=valgrind
+cmake --build --preset release
 ```
 
 Compile your program with the instrumented ponyc, then run it under Valgrind:
@@ -62,18 +62,18 @@ valgrind ./my-program
 ```
 
 !!! warning "Not available on OpenBSD"
-    Valgrind has no OpenBSD port, so its development headers aren't available and `use=valgrind` can't be built there. `gmake configure use=valgrind` is rejected on OpenBSD with an error.
+    Valgrind has no OpenBSD port, so its development headers aren't available and `valgrind` can't be built there. Configuring with `-DPONY_USES=valgrind` is rejected on OpenBSD with an error.
 
 !!! warning "Doesn't run on DragonFly BSD"
-    `use=valgrind` builds on DragonFly and the Pony programs it compiles link, but DragonFly ships Valgrind 3.15, which is too old to run a Pony program; it hangs on the runtime's memory arena. See [ponyc#5435](https://github.com/ponylang/ponyc/issues/5435).
+    `valgrind` builds on DragonFly and the Pony programs it compiles link, but DragonFly ships Valgrind 3.15, which is too old to run a Pony program; it hangs on the runtime's memory arena. See [ponyc#5435](https://github.com/ponylang/ponyc/issues/5435).
 
 ## Address Sanitizer
 
 [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) (ASan) detects memory errors at runtime: buffer overflows, use-after-free, double-free, and stack buffer overflows.
 
 ```bash
-make configure use=address_sanitizer
-make build
+cmake --preset release -DPONY_USES=address_sanitizer
+cmake --build --preset release
 ```
 
 Compile your program with the instrumented ponyc and run it normally. ASan reports errors to stderr as they occur.
@@ -83,8 +83,8 @@ Cannot be combined with `thread_sanitizer`.
 To catch errors in the Pony runtime's own allocations, pair it with `pool_memalign`, which routes every runtime allocation through `posix_memalign`/`free` so ASan can surround each one with redzones:
 
 ```bash
-make configure use=pool_memalign,address_sanitizer
-make build
+cmake --preset release -DPONY_USES=pool_memalign,address_sanitizer
+cmake --build --preset release
 ```
 
 The instrumented `ponyc` isn't LeakSanitizer-clean, so running it — during its own build, and whenever you use it to compile a program — needs `ASAN_OPTIONS` set in the environment. Without it the compiler reports its own leaks at exit, and on libc++ platforms aborts on false container overflows:
@@ -92,7 +92,7 @@ The instrumented `ponyc` isn't LeakSanitizer-clean, so running it — during its
 - **Linux**: `ASAN_OPTIONS=detect_leaks=0`
 - **FreeBSD and macOS**: `ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0` — the extra flag suppresses false positives from libc++ container annotations when the instrumented compiler shares `std::vector`/`std::string` with the non-instrumented vendored LLVM.
 
-A `use=pool_memalign,address_sanitizer` build's `ponyc` lands in `build/release-address_sanitizer-pool_memalign`, not `build/release`. For example, to compile a program on Linux:
+A `pool_memalign,address_sanitizer` build's `ponyc` lands in `build/release-address_sanitizer-pool_memalign`, not `build/release`. For example, to compile a program on Linux:
 
 ```bash
 ASAN_OPTIONS=detect_leaks=0 ./build/release-address_sanitizer-pool_memalign/ponyc path/to/your/program
@@ -101,15 +101,15 @@ ASAN_OPTIONS=detect_leaks=0 ./build/release-address_sanitizer-pool_memalign/pony
 Both options concern `ponyc` itself, not the programs it compiles. A correct Pony program is LeakSanitizer-clean at exit, so run a program you compiled with LeakSanitizer left on — it will report genuine leaks in your own code, such as memory you allocate through FFI and never free.
 
 !!! warning "Not available on OpenBSD or DragonFly BSD"
-    OpenBSD's base toolchain ships no AddressSanitizer runtime, and DragonFly BSD's `gcc13` toolchain doesn't build one either, so `use=address_sanitizer` can't be built on either. `gmake configure use=address_sanitizer` is rejected on both OpenBSD and DragonFly with an error.
+    OpenBSD's base toolchain ships no AddressSanitizer runtime, and DragonFly BSD's `gcc13` toolchain doesn't build one either, so `address_sanitizer` can't be built on either. Configuring with `-DPONY_USES=address_sanitizer` is rejected on both OpenBSD and DragonFly with an error.
 
 ## Thread Sanitizer
 
 [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) (TSan) detects data races at runtime.
 
 ```bash
-make configure use=thread_sanitizer
-make build
+cmake --preset release -DPONY_USES=thread_sanitizer
+cmake --build --preset release
 ```
 
 Compile your program with the instrumented ponyc and run it normally. TSan reports data races to stderr.
@@ -117,15 +117,15 @@ Compile your program with the instrumented ponyc and run it normally. TSan repor
 Cannot be combined with `address_sanitizer`.
 
 !!! warning "Not available on OpenBSD or DragonFly BSD"
-    OpenBSD's base toolchain ships no ThreadSanitizer runtime, and DragonFly BSD's `gcc13` toolchain doesn't build one either, so `use=thread_sanitizer` can't be built on either. `gmake configure use=thread_sanitizer` is rejected on both OpenBSD and DragonFly with an error.
+    OpenBSD's base toolchain ships no ThreadSanitizer runtime, and DragonFly BSD's `gcc13` toolchain doesn't build one either, so `thread_sanitizer` can't be built on either. Configuring with `-DPONY_USES=thread_sanitizer` is rejected on both OpenBSD and DragonFly with an error.
 
 ## Undefined Behavior Sanitizer
 
 [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) (UBSan) detects undefined behavior at runtime: signed integer overflow, null pointer dereference, misaligned memory access, and other categories.
 
 ```bash
-make configure use=undefined_behavior_sanitizer
-make build
+cmake --preset release -DPONY_USES=undefined_behavior_sanitizer
+cmake --build --preset release
 ```
 
 Compile your program with the instrumented ponyc and run it normally. UBSan reports violations to stderr.
@@ -133,31 +133,31 @@ Compile your program with the instrumented ponyc and run it normally. UBSan repo
 Can be combined with `address_sanitizer` or `thread_sanitizer`.
 
 !!! warning "Not available on OpenBSD or DragonFly BSD"
-    OpenBSD ships only the minimal UndefinedBehaviorSanitizer runtime, not the standalone runtime ponyc links against; DragonFly BSD's `gcc13` toolchain doesn't build the UBSan runtime at all. Either way, `use=undefined_behavior_sanitizer` can't be built there. `gmake configure use=undefined_behavior_sanitizer` is rejected on both OpenBSD and DragonFly with an error.
+    OpenBSD ships only the minimal UndefinedBehaviorSanitizer runtime, not the standalone runtime ponyc links against; DragonFly BSD's `gcc13` toolchain doesn't build the UBSan runtime at all. Either way, `undefined_behavior_sanitizer` can't be built there. Configuring with `-DPONY_USES=undefined_behavior_sanitizer` is rejected on both OpenBSD and DragonFly with an error.
 
 ## Coverage
 
 Instruments ponyc and the Pony runtime for source-level code coverage. It's built for working on ponyc itself: run a coverage-instrumented ponyc and its test suite to see which parts of the compiler and runtime C code each run exercises. To measure coverage of your own Pony code instead, you don't need a custom build — see [Coverage Reports](../testing/coverage-reports.md).
 
 ```bash
-make configure use=coverage
-make build
+cmake --preset release -DPONY_USES=coverage
+cmake --build --preset release
 ```
 
 The instrumentation comes from the host toolchain's coverage support — `-fprofile-instr-generate -fcoverage-mapping` under Clang, `-fprofile-arcs -ftest-coverage` under GCC. A Clang build writes an LLVM profile (`default.profraw`) that you turn into a report with `llvm-profdata` and `llvm-cov`; a GCC build writes `.gcda` files for `gcov` or `lcov`. These report tools aren't part of the ponyc build — install them separately. For the full workflow, see [Clang's source-based coverage guide](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) or the [gcov documentation](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html).
 
 !!! warning "Not available on OpenBSD"
-    OpenBSD's base toolchain ships an incomplete profiling runtime, so a coverage-instrumented ponyc can't be linked there. `gmake configure use=coverage` is rejected on OpenBSD with an error.
+    OpenBSD's base toolchain ships an incomplete profiling runtime, so a coverage-instrumented ponyc can't be linked there. Configuring with `-DPONY_USES=coverage` is rejected on OpenBSD with an error.
 
 ## DTrace / SystemTap
 
-The Pony runtime includes [USDT](https://illumos.org/books/dtrace/chp-usdt.html) (Userland Statically Defined Tracing) probes. They're consumed by SystemTap on Linux and by DTrace on FreeBSD. No other platform is supported: macOS removed DTrace, and neither DragonFly BSD nor OpenBSD ships a DTrace-compatible probe-generation tool (OpenBSD's `btrace` is a separate tracer with no USDT support). On DragonFly BSD and OpenBSD, `gmake configure use=dtrace` is rejected with an error rather than failing later in the build.
+The Pony runtime includes [USDT](https://illumos.org/books/dtrace/chp-usdt.html) (Userland Statically Defined Tracing) probes. They're consumed by SystemTap on Linux and by DTrace on FreeBSD. No other platform is supported: macOS removed DTrace, and neither DragonFly BSD nor OpenBSD ships a DTrace-compatible probe-generation tool (OpenBSD's `btrace` is a separate tracer with no USDT support). On DragonFly BSD and OpenBSD, configuring with `-DPONY_USES=dtrace` is rejected with an error rather than failing later in the build.
 
 Building requires a `dtrace`-compatible tool on your `PATH`:
 
 ```bash
-make configure use=dtrace
-make build
+cmake --preset release -DPONY_USES=dtrace
+cmake --build --preset release
 ```
 
 The probes are defined under the `pony` provider and cover:
@@ -177,7 +177,7 @@ For the full list of probes with parameter types and descriptions, see [`src/com
     Statically linked programs (`ponyc --static`) build and run but do not expose their probes to DTrace. FreeBSD registers USDT probes through the runtime linker, which a static binary doesn't use; trace a dynamically linked build instead.
 
 !!! warning "Runtime bitcode is incompatible with DTrace"
-    A ponyc built with `use=dtrace` cannot compile programs with `--runtimebc`, and rejects the combination with an error. Probe generation operates on native object files, not LLVM bitcode, so the bitcode runtime carries no probes — a `--runtimebc` binary would have none. Use the default static runtime to trace your program.
+    A ponyc built with `dtrace` cannot compile programs with `--runtimebc`, and rejects the combination with an error. Probe generation operates on native object files, not LLVM bitcode, so the bitcode runtime carries no probes — a `--runtimebc` binary would have none. Use the default static runtime to trace your program.
 
 ## Runtime Statistics
 
@@ -191,8 +191,8 @@ Two options are available:
 For most debugging scenarios, enable both:
 
 ```bash
-make configure use=runtimestats,runtimestats_messages
-make build
+cmake --preset release -DPONY_USES=runtimestats,runtimestats_messages
+cmake --build --preset release
 ```
 
 For details on the available tracking functions and how to call them from Pony code, see [Tracking Memory Usage at Runtime](../debugging/track-memory-usage.md).
@@ -202,8 +202,8 @@ For details on the available tracking functions and how to call them from Pony c
 Runtime tracing records events from the Pony scheduler, actor lifecycle, and message passing. Events can be written to a trace file in the background, or stored in in-memory circular buffers that dump to stderr on abnormal termination (SIGILL, SIGSEGV, SIGBUS). Trace files use Chromium JSON format and can be viewed with [Perfetto](https://perfetto.dev/).
 
 ```bash
-make configure use=runtime_tracing
-make build
+cmake --preset release -DPONY_USES=runtime_tracing
+cmake --build --preset release
 ```
 
 For details on tracing options and usage, see [Tracing Pony Programs](../debugging/tracing.md).
@@ -217,8 +217,8 @@ A program run under systematic testing has to be deterministic, and keeping it t
 Systematic testing requires two options together:
 
 ```bash
-make configure use=scheduler_scaling_pthreads,systematic_testing
-make build
+cmake --preset release -DPONY_USES=scheduler_scaling_pthreads,systematic_testing
+cmake --build --preset release
 ```
 
 The `scheduler_scaling_pthreads` option is required because systematic testing needs pthread-based scheduler scaling rather than the default implementation.

--- a/docs/use/cross-compilation.md
+++ b/docs/use/cross-compilation.md
@@ -20,27 +20,28 @@ Cross-compiling a Pony program requires three things:
 
 ## Building the Cross-Compiled Runtime
 
-Until pre-built runtimes ship with ponyc releases, you need to build the runtime from the ponyc source. This requires a full build environment including LLVM (built via `make libs`).
+Until pre-built runtimes ship with ponyc releases, you need to build the runtime from the ponyc source. This needs the LLVM libraries built, but not a full native ponyc — you compile your program with your host `ponyc` (a ponyup install or a from-source build, as covered in [What You Need](#what-you-need) above).
 
 ```bash
 git clone https://github.com/ponylang/ponyc.git
 cd ponyc
-make libs build_flags=-j8
-make configure config=release
-make build config=release
+cmake -DJOBS=8 -P lib/build-libs.cmake
 ```
 
-Then build the cross-compiled runtime for your target:
+Then build the cross-compiled runtime for your target. There's no preset for cross-builds, so configure a target-specific build directory directly, then build only the `libponyrt` and `crt_objects` targets:
 
 ```bash
-make cross-libponyrt config=release \
-  CC=<cross-compiler> CXX=<cross-c++> \
-  arch=<arch> \
-  cross_cflags="<target-cflags>" \
-  cross_lflags="<target-lflags>"
+cmake -B build/<arch>/build_release -S . \
+  -DCMAKE_CROSSCOMPILING=true -DCMAKE_SYSTEM_NAME=Linux \
+  -DCMAKE_SYSTEM_PROCESSOR=<arch> \
+  -DCMAKE_C_COMPILER=<cross-compiler> -DCMAKE_CXX_COMPILER=<cross-c++> \
+  -DPONY_CROSS_LIBPONYRT=true -DCMAKE_BUILD_TYPE=release \
+  -DCMAKE_C_FLAGS="<target-cflags>" -DCMAKE_CXX_FLAGS="<target-cflags>" \
+  -DPONY_ARCH=<arch> -DLL_FLAGS="<target-llc-flags>"
+cmake --build build/<arch>/build_release --config release --target libponyrt crt_objects
 ```
 
-The output goes into a directory named after the architecture (e.g., `build/rv64gc/release/`). You point `PONYPATH` at this directory when compiling your program.
+The build tree goes in `build/<arch>/build_release` and the compiled runtime in `build/<arch>/release` (for example, `build/rv64gc/release/`). To compile a program, run your host `ponyc` with `PONYPATH` pointed at that output directory.
 
 See the target-specific guides below for the exact commands for each supported target.
 

--- a/docs/use/cross-compilation/arm-linux.md
+++ b/docs/use/cross-compilation/arm-linux.md
@@ -19,12 +19,16 @@ The Pony runtime needs to be compiled for ARM. This requires the ponyc source tr
 From the ponyc source directory:
 
 ```bash
-make cross-libponyrt config=release \
-  CC=arm-linux-gnueabi-gcc \
-  CXX=arm-linux-gnueabi-g++ \
-  arch=armv7-a \
-  cross_cflags="-march=armv7-a -mtune=cortex-a9" \
-  cross_lflags="-O3;-march=arm"
+cmake -B build/armv7-a/build_release -S . \
+  -DCMAKE_CROSSCOMPILING=true -DCMAKE_SYSTEM_NAME=Linux \
+  -DCMAKE_SYSTEM_PROCESSOR=armv7-a \
+  -DCMAKE_C_COMPILER=arm-linux-gnueabi-gcc \
+  -DCMAKE_CXX_COMPILER=arm-linux-gnueabi-g++ \
+  -DPONY_CROSS_LIBPONYRT=true -DCMAKE_BUILD_TYPE=release \
+  -DCMAKE_C_FLAGS="-march=armv7-a -mtune=cortex-a9" \
+  -DCMAKE_CXX_FLAGS="-march=armv7-a -mtune=cortex-a9" \
+  -DPONY_ARCH=armv7-a -DLL_FLAGS="-O3;-march=arm"
+cmake --build build/armv7-a/build_release --config release --target libponyrt crt_objects
 ```
 
 The output lands in `build/armv7-a/release/`.

--- a/docs/use/cross-compilation/armhf-linux.md
+++ b/docs/use/cross-compilation/armhf-linux.md
@@ -21,12 +21,16 @@ The Pony runtime needs to be compiled for ARM hard-float. This requires the pony
 From the ponyc source directory:
 
 ```bash
-make cross-libponyrt config=release \
-  CC=arm-linux-gnueabihf-gcc \
-  CXX=arm-linux-gnueabihf-g++ \
-  arch=armv7-a \
-  cross_cflags="-march=armv7-a -mtune=cortex-a9" \
-  cross_lflags="-O3;-march=arm"
+cmake -B build/armv7-a/build_release -S . \
+  -DCMAKE_CROSSCOMPILING=true -DCMAKE_SYSTEM_NAME=Linux \
+  -DCMAKE_SYSTEM_PROCESSOR=armv7-a \
+  -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \
+  -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ \
+  -DPONY_CROSS_LIBPONYRT=true -DCMAKE_BUILD_TYPE=release \
+  -DCMAKE_C_FLAGS="-march=armv7-a -mtune=cortex-a9" \
+  -DCMAKE_CXX_FLAGS="-march=armv7-a -mtune=cortex-a9" \
+  -DPONY_ARCH=armv7-a -DLL_FLAGS="-O3;-march=arm"
+cmake --build build/armv7-a/build_release --config release --target libponyrt crt_objects
 ```
 
 The output lands in `build/armv7-a/release/`.

--- a/docs/use/cross-compilation/riscv64-linux.md
+++ b/docs/use/cross-compilation/riscv64-linux.md
@@ -22,12 +22,16 @@ The Pony runtime needs to be compiled for RISC-V. This requires the ponyc source
 From the ponyc source directory:
 
 ```bash
-make cross-libponyrt config=release \
-  CC=riscv64-linux-gnu-gcc-10 \
-  CXX=riscv64-linux-gnu-g++-10 \
-  arch=rv64gc \
-  cross_cflags="-march=rv64gc -mtune=rocket" \
-  cross_lflags="-march=riscv64"
+cmake -B build/rv64gc/build_release -S . \
+  -DCMAKE_CROSSCOMPILING=true -DCMAKE_SYSTEM_NAME=Linux \
+  -DCMAKE_SYSTEM_PROCESSOR=rv64gc \
+  -DCMAKE_C_COMPILER=riscv64-linux-gnu-gcc-10 \
+  -DCMAKE_CXX_COMPILER=riscv64-linux-gnu-g++-10 \
+  -DPONY_CROSS_LIBPONYRT=true -DCMAKE_BUILD_TYPE=release \
+  -DCMAKE_C_FLAGS="-march=rv64gc -mtune=rocket" \
+  -DCMAKE_CXX_FLAGS="-march=rv64gc -mtune=rocket" \
+  -DPONY_ARCH=rv64gc -DLL_FLAGS="-march=riscv64"
+cmake --build build/rv64gc/build_release --config release --target libponyrt crt_objects
 ```
 
 The output lands in `build/rv64gc/release/`.

--- a/docs/use/debugging/tracing.md
+++ b/docs/use/debugging/tracing.md
@@ -17,10 +17,10 @@ Once a trace has been captured, it can be viewed with the [perfetto trace viewer
 Tracing is not enabled by default. You need to build ponyc from source with the `runtime_tracing` option:
 
 ```bash
-make configure use=runtime_tracing
-make build
+cmake --preset release -DPONY_USES=runtime_tracing
+cmake --build --preset release
 ```
 
-The resulting `ponyc` binary is in `build/release/`. Use it in place of your system `ponyc` to compile programs with tracing enabled.
+The resulting `ponyc` binary is in `build/release-runtime_tracing/` — enabling an option suffixes the output directory with the option name. Use it in place of your system `ponyc` to compile programs with tracing enabled.
 
 For full source build instructions, see [Custom ponyc Builds for Debugging](../compiler/custom-ponyc-builds.md).

--- a/docs/use/debugging/track-memory-usage.md
+++ b/docs/use/debugging/track-memory-usage.md
@@ -67,10 +67,10 @@ or,
 Memory tracking is not enabled by default. You need to build ponyc from source with the `runtimestats` and `runtimestats_messages` options:
 
 ```bash
-make configure use=runtimestats,runtimestats_messages
-make build
+cmake --preset release -DPONY_USES=runtimestats,runtimestats_messages
+cmake --build --preset release
 ```
 
-The resulting `ponyc` binary is in `build/release/`. Use it in place of your system `ponyc` to compile programs with memory tracking enabled.
+The resulting `ponyc` binary is in `build/release-runtimestats-runtimestats_messages/` — enabling options suffixes the output directory with the option names. Use it in place of your system `ponyc` to compile programs with memory tracking enabled.
 
 For full source build instructions, see [Custom ponyc Builds for Debugging](../compiler/custom-ponyc-builds.md).


### PR DESCRIPTION
ponyc is moving its build system from a GNU Make wrapper (`Makefile`, `make.ps1`) to CMake presets. `make libs / configure / build / test / install`, the `cross-libponyrt` target, and `make.ps1` no longer exist. This translates every website page that documented those commands to the new `cmake`/`ctest` preset equivalents, mirroring ponyc's rewritten `BUILD.md`.

Pages updated:

- `contribute/compiler/building-ponyc-from-source.md` — the full command surface (libs, configure, build, test, install, clean), LTO/bitcode, `PONY_USES`, IDE integration, the BSD/Raspbian/Asahi platform notes, and the `PONY_TEST_DEBUGGER` debugger recipe.
- `use/compiler/custom-ponyc-builds.md` — every `use=` option translated to `-DPONY_USES=`.
- `use/cross-compilation.md` and the riscv64 / arm / armhf target guides — `make cross-libponyrt` translated to the direct `cmake` cross invocation.
- `contribute/developer-resources/arm-development-with-rpi-4.md`, `use/debugging/tracing.md`, `use/debugging/track-memory-usage.md`.
- `faq/compiling.md` — the dead `make default_pic=true` command dropped.

Notes on a few non-mechanical points:

- `use=` splits two ways: runtime options go in `-DPONY_USES`, but `lto`, `runtime-bitcode`, and `arch` become their own cache vars (`-DPONY_USE_LTO`, `-DPONY_RUNTIME_BITCODE`, `-DPONY_ARCH` / arch presets).
- The FAQ's `make default_pic=true` never worked (the Makefile had no such variable) and a from-source ponyc already defaults `--pic` on, so the entry now states that instead.
- Two output-directory lines that were already wrong before this change (a `use=` build lands in a suffixed directory, not plain `build/release`) are corrected while translating.
- The compiler-mismatch warning was dropped: the new CMake build has no matching-pair check, so the old "the build will error if you mix clang with g++" claim is no longer true.
- The cross-compilation setup no longer builds a native ponyc it doesn't use — building the cross runtime only needs the LLVM libraries, and you compile with your host `ponyc`.
- The Raspberry Pi 4 build section is scoped to 32-bit Raspbian, pointing 64-bit readers to the 64-bit Raspbian instructions.
- The cross blocks keep `-DLL_FLAGS=...` to mirror ponyc's CI recipe, but the false "passed through to `llc`" claim is dropped: nothing in ponyc's CMake consumes it and there's no `llc` step.