### PR TITLE
Update runtime tracing docs for Windows support

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -45,7 +45,8 @@ Tier 3 jobs are defined in the [ponyc-tier3](https://github.com/ponylang/ponyc/b
 
 Weekly checks build and test with non-default compiler directives and sanitizers. They're valuable for catching breakage in code paths that don't get exercised during normal builds, but they rarely surface issues beyond confirming that nothing has been broken. They run on a weekly schedule (Thursday 3 AM UTC), gated on whether there were commits in the last 7 days.
 
-- Use directive variants (`dtrace`, `pool_memalign`, `pool_retain`, `runtimestats`, `runtime_tracing`)
+- Use directive variants on Linux (`dtrace`, `pool_memalign`, `pool_retain`, `runtimestats`, `runtime_tracing`)
+- Use directive variants on Windows (`runtime_tracing`)
 - Sanitizers (address sanitizer, undefined behavior sanitizer)
 - macOS sanitizer and `dtrace` smoke tests (arm64 and x86-64)
 

--- a/docs/use/compiler/custom-ponyc-builds.md
+++ b/docs/use/compiler/custom-ponyc-builds.md
@@ -199,7 +199,7 @@ For details on the available tracking functions and how to call them from Pony c
 
 ## Runtime Tracing
 
-Runtime tracing records events from the Pony scheduler, actor lifecycle, and message passing. Events can be written to a trace file in the background, or stored in in-memory circular buffers that dump to stderr on abnormal termination (SIGILL, SIGSEGV, SIGBUS). Trace files use Chromium JSON format and can be viewed with [Perfetto](https://perfetto.dev/).
+Runtime tracing records events from the Pony scheduler, actor lifecycle, and message passing. Events can be written to a trace file in the background, or stored in in-memory circular buffers that dump to stderr when the program crashes — a fatal signal such as SIGSEGV or SIGILL on Linux and macOS, or a fault such as an access violation on Windows. Trace files use Chromium JSON format and can be viewed with [Perfetto](https://perfetto.dev/).
 
 ```bash
 make configure use=runtime_tracing

--- a/docs/use/debugging/tracing.md
+++ b/docs/use/debugging/tracing.md
@@ -1,6 +1,6 @@
 # Tracing Pony Programs
 
-The Pony runtime can be built to be able to either write a trace to file in the background or work in a "flight recorder" mode where events are stored into in memory circular buffers and written to stderr in case of abnormal program behavior (SIGILL, SIGSEGV, SIGBUS, etc).
+The Pony runtime can be built to be able to either write a trace to file in the background or work in a "flight recorder" mode where events are stored into in memory circular buffers and written to stderr when the program crashes — a fatal signal such as SIGSEGV or SIGILL on Linux and macOS, or a fault such as an access violation on Windows.
 
 Runtime tracing is helpful in understanding how the runtime works and for debugging issues with the runtime.
 
@@ -22,5 +22,7 @@ make build
 ```
 
 The resulting `ponyc` binary is in `build/release/`. Use it in place of your system `ponyc` to compile programs with tracing enabled.
+
+The commands above are for the Unix Makefile build. To enable `runtime_tracing` on Windows, build ponyc from source following ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md).
 
 For full source build instructions, see [Custom ponyc Builds for Debugging](../compiler/custom-ponyc-builds.md).


### PR DESCRIPTION
ponylang/ponyc#5676 ports the `runtime_tracing` build option — file-trace mode and the flight recorder — to Windows. It was a compile error there before.

This updates the three places the site described runtime tracing in POSIX-only terms:

- The flight recorder's crash-dump descriptions (`tracing.md`, `custom-ponyc-builds.md`) named only POSIX signals. They now cover the Windows trigger (a fault such as an access violation) alongside the Linux and macOS signals.
- `tracing.md` now points Windows readers at ponyc's BUILD.md, since the build commands shown are the Unix Makefile path and the site doesn't document Windows source builds.
- The CI tiers page lists the new `use_directives_windows` weekly check.