### PR TITLE
Unify the from-source build's compiler and PIC overrides in the docs

### DIFF
--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -151,14 +151,14 @@ Replace `build_release` with `build_debug` if you're using a debug configuration
 
 On OpenBSD, use `doas` instead of `sudo` for installation. All three BSDs need `gmake` installed as a package (CMake and the LLVM build shell out to it), but you drive the build with `cmake` and `ctest` directly, the same as everywhere else.
 
-On DragonFly BSD, the base compiler (GCC 8.3) cannot build the vendored LLVM. Install `gcc13` from packages and pass `-DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13` to `cmake -P lib/build-libs.cmake`, and `-DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13` to the configure step. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#dragonfly) for full instructions.
+On DragonFly BSD, the base compiler (GCC 8.3) cannot build the vendored LLVM. Install `gcc13` from packages and pass `-DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13` to both `cmake -P lib/build-libs.cmake` and the configure step. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#dragonfly) for full instructions.
 
 ### 32-bit Raspbian
 
 Only GCC works on 32-bit Raspbian — clang is not supported. You also need to build for native CPU tuning:
 
 ```bash
-cmake -DCC=gcc -DCXX=g++ -P lib/build-libs.cmake
+cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -P lib/build-libs.cmake
 cmake --preset release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-march=native -mtune=native" -DCMAKE_CXX_FLAGS="-march=native -mtune=native"
 cmake --build --preset release
 sudo cmake --install build/build_release
@@ -166,10 +166,10 @@ sudo cmake --install build/build_release
 
 ### 64-bit Raspbian
 
-Build for the `armv8-a` architecture, and pass the position-independent-code flag to both the libs step (`-DPIC`) and the configure step (`-DPONY_PIC_FLAG`). The install reads the arch-specific build directory:
+Build for the `armv8-a` architecture, and pass the position-independent-code flag (`-DPONY_PIC_FLAG`) to both the libs step and the configure step. The install reads the arch-specific build directory:
 
 ```bash
-cmake -DPIC=-fPIC -P lib/build-libs.cmake
+cmake -DPONY_PIC_FLAG=-fPIC -P lib/build-libs.cmake
 cmake --preset armv8-a-release -DPONY_PIC_FLAG=-fPIC
 cmake --build --preset armv8-a-release
 sudo cmake --install build/build_armv8-a-release

--- a/docs/contribute/developer-resources/arm-development-with-rpi-4.md
+++ b/docs/contribute/developer-resources/arm-development-with-rpi-4.md
@@ -79,9 +79,9 @@ Things you might want to do that are left to an exercise to the user:
 
 These steps are for a 32-bit Raspbian. On a 64-bit Raspbian, follow the [64-bit Raspbian](../compiler/building-ponyc-from-source.md#64-bit-raspbian) section instead — clang works there and you build for the `armv8-a` architecture.
 
-To build pony after you've cloned the source code, you'll follow the directions below. Building with `clang` isn't currently supported on 32-bit Arm, and the CMake presets default to `clang`, so you need to point the build at `gcc`. That means `-DCC=/usr/bin/gcc -DCXX=/usr/bin/g++` at the libs step and `-DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++` at the configure step.
+To build pony after you've cloned the source code, you'll follow the directions below. Building with `clang` isn't currently supported on 32-bit Arm, and the CMake presets default to `clang`, so you need to point the build at `gcc`. That means `-DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++` at both the libs step and the configure step.
 
-- `cmake -DCC=/usr/bin/gcc -DCXX=/usr/bin/g++ -DJOBS=4 -P lib/build-libs.cmake`
+- `cmake -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DJOBS=4 -P lib/build-libs.cmake`
 
 note, this will probably take about 3 hours. make sure you aren't logged out of ssh.
 


### PR DESCRIPTION
The ponyc from-source build docs told readers to override the compiler and the position-independent-code flag with `-DCC`/`-DCXX`/`-DPIC` at the libs step but `-DCMAKE_C_COMPILER`/`-DCMAKE_CXX_COMPILER`/`-DPONY_PIC_FLAG` at the configure step — two spellings for one intent.

ponylang/ponyc#5697 makes `lib/build-libs.cmake` read the standard CMake names directly, so one spelling overrides each at both steps. This updates the from-source build pages (`building-ponyc-from-source.md` and the RPi 4 dev-resources page) to match.