### PR TITLE
Say who reads Last Week in Pony

### DIFF
--- a/.claude/skills/lwip/SKILL.md
+++ b/.claude/skills/lwip/SKILL.md
@@ -6,6 +6,28 @@ disable-model-invocation: true
 
 Create a new "Last Week in Pony" blog post.
 
+## Who reads this
+
+People who write Pony, and people following the language. Not people who work
+on whatever subsystem an item happens to be about.
+
+**What they know.** They know Pony and they write Pony programs. They don't
+know the internals of ponyc, of lori, or of whatever library an item covers,
+and they have not read the changelogs, the PRs, or the design docs you read to
+write the post. A fact that only lands for someone who has read what you read
+buries the item, however true and however well sourced it is.
+
+**Why they are reading.** Some of them write Pony and want the practical news:
+what will break their code, what to upgrade for, what fixes a problem they
+might have hit. A lot of them are lookie-loos who don't use Pony and never will
+act on any of it. They read because it's interesting to watch a language get
+built. Both halves matter. An item that's useful but dull serves half the
+audience, and detail only a maintainer could care about serves neither.
+
+The job is to give the major news and entertain people who want to know what's
+going on with Pony. It is not to account for everything that happened. Leaving
+things out is part of the work.
+
 ## Critical: don't fabricate
 
 Every factual claim in the post must come from a verifiable source: the


### PR DESCRIPTION
The skill never named its audience, so posts got written at the level of whoever gathered the material: someone who had read the changelogs, the PRs, and the design docs. Detail that only makes sense to a maintainer of the subsystem in question buried the news it was supposed to support.

Adds a "Who reads this" section at the top, answering two questions. What do they know, which sets the level and what has to be explained. Why are they reading, which sets what belongs in a post at all.

The part that matters most is that many readers don't use Pony and never will act on anything in a post. They read because it's interesting to watch a language get built. So an item that's useful but dull serves half the audience, and detail only a maintainer could care about serves neither.

It also states that the job is the major news rather than a complete accounting. Nothing in the skill licensed leaving things out, so the default was to cover everything.
