### PR TITLE
Set an item's detail by what a reader can do with it

### DIFF
--- a/.claude/skills/lwip/SKILL.md
+++ b/.claude/skills/lwip/SKILL.md
@@ -28,6 +28,29 @@ The job is to give the major news and entertain people who want to know what's
 going on with Pony. It is not to account for everything that happened. Leaving
 things out is part of the work.
 
+## What state is the work in
+
+How much an item gets depends on what a reader can do with it.
+
+**Released.** They can go get it. Say what it does for them. The release notes
+carry the full detail, so don't reproduce them — a post that re-explains every
+fix does the release notes' job twice and buries its own news doing it.
+
+**Merged but not released.** They can't get it yet, so per-fix detail helps
+nobody. Say what's coming, when, and why it's worth knowing about now.
+
+**Not merged.** Say what's coming, why, whatever is genuinely settled — that
+it's a breaking change, roughly when — and link to where they can follow along.
+Nothing else. The design docs and PRs behind unfinished work contradict each
+other and use provisional names, because that's what unfinished work looks
+like. Mining them for mechanism produces detail that's wrong as often as it's
+right, and the links carry it for anyone who wants it.
+
+**Real but far off.** A plan that won't be real for a long time is a
+distraction rather than news. Every fact about it can be true and sourced and
+it still costs the reader more than it gives them. Wait until there's something
+to do about it.
+
 ## Critical: don't fabricate
 
 Every factual claim in the post must come from a verifiable source: the


### PR DESCRIPTION
Nothing in the skill said that work in flight gets reported differently from work that shipped, so unmerged work got written up at the same depth as released work. That's wrong in both directions. Released work gets its full explanation in the release notes, so repeating it in a post buries the post's own news. Work that hasn't landed can't be acted on at all, so mechanism about it serves nobody.

Adds a "What state is the work in" section covering four cases: released, merged but not released, not merged, and real but far off. The organizing question is what a reader can do with the item, which is the audience question from the section above applied to how much detail something earns.

Two things in it worth calling out. Unfinished sources are unreliable in a specific way: design docs and PRs for work in progress contradict each other and use provisional names, because that's what unfinished work looks like, so reading them for mechanism produces detail that's wrong as often as it's right. And the last case fails no accuracy test at all, only the audience one, since a real plan that won't be real for a long time costs the reader more than it gives them.
