### PR TITLE
Note 32-bit ARM as a best-effort platform

### DIFF
--- a/docs/learn/installing-pony.md
+++ b/docs/learn/installing-pony.md
@@ -8,7 +8,7 @@ The easiest way to install Pony is through [ponyup](https://github.com/ponylang/
 
 | OS \ CPU | `amd64` | `arm64` | `arm32` | `riscv64` |
 |---|---|---|---|---|
-| **Linux** | ✅ Released | ✅ Released | 🧪 Tested | 🧪 Tested |
+| **Linux** | ✅ Released | ✅ Released | 🔧 Best-effort | 🧪 Tested |
 | **macOS** | ✅ Released | ✅ Released | — | — |
 | **Windows** | ✅ Released | ✅ Released | — | — |
 | **FreeBSD** | 🧪 Tested | ✗ Unsupported | — | — |
@@ -17,12 +17,13 @@ The easiest way to install Pony is through [ponyup](https://github.com/ponylang/
 
 * ✅ **Released** — official prebuilt binaries; also tested in CI
 * 🧪 **Tested** — tested in CI; build from source (no prebuilt binary)
+* 🔧 **Best-effort** — not in CI; built from source and tested periodically on real hardware
 * ✗ **Unsupported** — no support
 * — **Not applicable** — combination doesn't exist
 
 On Windows, the minimum supported version is **Windows 11 / Windows Server 2022** (build 20348). Pony's networking uses an OS readiness API introduced in that build; earlier versions, including Windows 10, are unsupported.
 
-Platforms marked 🧪 Tested have no prebuilt binary; you'll need to [build ponyc from source](https://github.com/ponylang/ponyc/blob/main/BUILD.md).
+Platforms marked 🧪 Tested or 🔧 Best-effort have no prebuilt binary; you'll need to [build ponyc from source](https://github.com/ponylang/ponyc/blob/main/BUILD.md).
 
 ## Install ponyup
 

--- a/docs/use/cross-compilation/arm-linux.md
+++ b/docs/use/cross-compilation/arm-linux.md
@@ -2,6 +2,8 @@
 
 This guide covers cross-compiling Pony programs from an x86-64 Linux host to 32-bit ARM Linux (glibc, soft-float ABI). This targets ARMv7-A devices using software floating point. If your target uses hardware floating point, see [ARM Linux (Hard-Float)](armhf-linux.md) instead.
 
+32-bit ARM is a best-effort target: it is not tested in CI, but is built and tested periodically on real hardware. A change can break it between those checks.
+
 ## Install the Cross-Toolchain
 
 On Debian/Ubuntu, install the ARM cross-compiler and QEMU for testing:

--- a/docs/use/cross-compilation/armhf-linux.md
+++ b/docs/use/cross-compilation/armhf-linux.md
@@ -4,6 +4,8 @@ This guide covers cross-compiling Pony programs from an x86-64 Linux host to 32-
 
 If your target doesn't have an FPU or uses software floating point, see [ARM Linux (Soft-Float)](arm-linux.md) instead.
 
+32-bit ARM is a best-effort target: it is not tested in CI, but is built and tested periodically on real hardware. A change can break it between those checks.
+
 ## Install the Cross-Toolchain
 
 On Debian/Ubuntu, install the ARM hard-float cross-compiler and QEMU for testing:


### PR DESCRIPTION
Mark 32-bit ARM (arm32) as best-effort in the supported-platforms matrix, and add a short best-effort note to the two 32-bit ARM cross-compilation guides and the Raspberry Pi 4 development guide.

Companion to ponylang/ponyc#5795, which drops the 32-bit ARM CI jobs. 32-bit ARM is no longer tested in CI; it is built and tested periodically on real hardware.
