### PR TITLE
Replace super-linter with dedicated linter images

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,19 +10,13 @@ permissions:
   packages: read
 
 jobs:
-  superlinter:
+  lint-markdown:
     name: Lint markdown
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v6.0.2
-      - name: Lint codebase
-        uses: docker://github/super-linter:v3.8.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
-          VALIDATE_MD: true
-          DEFAULT_BRANCH: main
+      - uses: actions/checkout@v6.0.2
+      - name: Lint markdown
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-markdownlint:20260810
 
   check-spelling:
     name: Spellcheck markdown

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -3,5 +3,6 @@
   "MD026": false,
   "MD033": false,
   "MD024": false,
-  "MD007": false
+  "MD007": false,
+  "MD051": false
 }

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -6,6 +6,7 @@
   "MD007": false,
   "MD051": false,
   "MD034": false,
+  "MD045": false,
   "MD049": false,
   "MD050": false
 }

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -4,5 +4,8 @@
   "MD033": false,
   "MD024": false,
   "MD007": false,
-  "MD051": false
+  "MD051": false,
+  "MD034": false,
+  "MD049": false,
+  "MD050": false
 }


### PR DESCRIPTION
Replace the super-linter Docker image with a dedicated markdownlint image from shared-docker. Faster CI — small purpose-built image instead of the 2GB+ super-linter.