### PR TITLE
Add pool_retain to PONY_USES options table

### DIFF
--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -123,6 +123,7 @@ The available options:
 | `runtime_tracing` | Runtime tracing/profiling |
 | `pooltrack` | Pool memory tracking |
 | `pool_memalign` | Pool allocator with memalign |
+| `pool_retain` | Pool allocator retains freed pages instead of returning them to the OS |
 
 For detailed usage of valgrind, sanitizers, DTrace, and systematic testing, see [Custom ponyc Builds](../../use/compiler/custom-ponyc-builds.md).
 


### PR DESCRIPTION
The table listed pooltrack and pool_memalign but omitted pool_retain,
which is a valid option in ponyc's PonyUses.cmake. When defined, the pool
allocator skips decommitting freed pages back to the OS.

Closes #1393