### PR TITLE
Fix stale repo name and local-install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ Temporary Items
 
 ### mkdocs ##
 /site/
+/venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ date: YYYY-MM-DDTHH:MM:SS-04:00
 ```
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony, check out [our website](https://ponylang.io) or our [Zulip community](https://ponylang.zulipchat.com).
 
-Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang-website/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 ```
 
 ### Review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We don't owe anyone our time. We choose to give it. Don't waste it.
 
 ## mkdocs
 
-The Pony website is generated using [mkdocs], a static website generator. If you are making larger changes to the site, you will need to install `mkdocs` locally to verify your changes are working.
+The Pony website is generated using [mkdocs], a static website generator. If you are making larger changes to the site, you will need to install `mkdocs` and its plugins locally to verify your changes are working.
 
 ## Ponylang.io hosting
 
@@ -46,16 +46,21 @@ To see the preview, on the PR page select `Show all checks` and then click `Deta
 
 ## Developing locally with mkdocs
 
-To do larger changes, you'll want to install mkdocs locally so you can test your changes. For detailed instructions on using [mkdocs], please refer to its website.
-
-For simpler tasks, once you have mkdocs installed, you should be able to:
+To do larger changes, you'll want to build the site locally so you can test your changes. The site depends on several mkdocs plugins pinned in `requirements.txt`. Install them in a virtualenv:
 
 ```bash
-cd ponylang-website
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Then start the local dev server:
+
+```bash
 mkdocs serve
 ```
 
-Which will start up a local webserver that will serve the Ponylang website on `http://localhost:8000`.
+This starts a local webserver at `http://localhost:8000` that rebuilds pages as you edit them.
 
 Once you are happy with your changes, commit them and submit a PR. Before doing that, please read the following 'How to submit a pull request' section.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ponylang.github.io
+# ponylang-website
 
-Source content for the Pony website. You can see the final product at [http://www.ponylang.io/](http://www.ponylang.io).
+Source for the [Pony website](https://www.ponylang.io).
 
 ## Interested in contributing?
 


### PR DESCRIPTION
The README title still said `ponylang.github.io` and the LWIP footer boilerplate in AGENTS.md linked to the old repo name. The local dev setup in CONTRIBUTING.md told contributors to `pip install mkdocs`, which fails because the site depends on plugins pinned in `requirements.txt`.

- README: title and link updated to match the current repo name
- AGENTS.md: LWIP footer boilerplate URL updated from `ponylang/ponylang.github.io` to `ponylang/ponylang-website`
- CONTRIBUTING.md: replaced vague "install mkdocs" with concrete virtualenv + `pip install -r requirements.txt` instructions
- .gitignore: added `venv/` since the new instructions create one

Existing blog post footers still use the old `ponylang.github.io` URL. GitHub redirects keep those links working. The AGENTS.md template fix prevents future posts from using the stale name; updating 400+ historical posts is separate work if wanted.

Closes #1334
