### PR TITLE
Add CI infrastructure guide

### DIFF
--- a/docs/contribute/ci.md
+++ b/docs/contribute/ci.md
@@ -1,21 +1,21 @@
 # CI
 
-Information related to our various CI systems.
+The CI system is GitHub Actions. Most repos use a standard set of 14 workflow files from [ponylang/templates](https://github.com/ponylang/templates), covering PR checks, on-merge automation, release automation, and maintenance. A few repos — ponyc, ponylang-website, and shared-docker — diverge from the template.
 
-## CI systems in use
+All Linux CI runs in Docker containers. Build images are hosted on GitHub Container Registry under the [ponylang organization's packages](https://github.com/orgs/ponylang/packages).
 
-Our CI system is GitHub Actions.
-
-A few pony project might still be using legacy CI setups with Appveyor, CircleCI, CirrusCI, or TravisCI. If you see any of these, you are encouraged to submit a PR to update them to using GitHub Actions.
-
-## Additional infrastructure
-
-All our CI for Linux is done in Docker images. See [CI image organization](ci/ci-image-organization.md) for more information about where you can find image definitions. All build images are stored in GitHub Container Registry. You can find a list under the [ponylang organization's packages](https://github.com/orgs/ponylang/packages).
+A few Pony projects might still be using legacy CI setups with Appveyor, CircleCI, CirrusCI, or TravisCI. If you see any of these, you are encouraged to submit a PR to update them to use GitHub Actions.
 
 ---
 
-- [CI Image Organization](ci/ci-image-organization.md)
-- [GitHub Actions and Security](ci/gh-actions-security.md)
-- [ponyc CI Tiers](ci/ponyc-ci-tiers.md)
-- [Scheduled Jobs](ci/scheduled-jobs.md)
-- [Triggered Jobs](ci/triggered-jobs.md)
+- [Tokens and Secrets](ci/tokens-and-secrets.md) — `GITHUB_TOKEN` vs. `RELEASE_TOKEN` and the full secret inventory
+- [Standard Workflows](ci/standard-workflows.md) — what the 14 template workflows do
+- [Release Pipeline](ci/release-pipeline.md) — the three-tag release chain
+- [Nightly and Breakage Pipeline](ci/nightly-and-breakage-pipeline.md) — the daily cascade from ponyc nightly to library breakage tests
+- [Bot Actions](ci/bot-actions.md) — the custom GitHub Actions that automate changelog, release, and documentation tasks
+- [Setting Up a New Repo](ci/setting-up-a-new-repo.md) — adding a new repo with CI, releases, and breakage testing
+- [CI Image Organization](ci/ci-image-organization.md) — Docker image naming and tagging conventions
+- [GitHub Actions and Security](ci/gh-actions-security.md) — action pinning, threat model, and security policies
+- [ponyc CI Tiers](ci/ponyc-ci-tiers.md) — ponyc's tiered testing schedule
+- [Scheduled Jobs](ci/scheduled-jobs.md) — all scheduled CI jobs and their times
+- [Triggered Jobs](ci/triggered-jobs.md) — cross-repo dispatch events and their receivers

--- a/docs/contribute/ci/bot-actions.md
+++ b/docs/contribute/ci/bot-actions.md
@@ -1,0 +1,57 @@
+# Bot Actions
+
+Ponylang maintains five active custom GitHub Actions, all Docker-based and hosted on GitHub Container Registry (GHCR). A sixth repo (accepted-rfc-bot-action) exists but is an inactive stub.
+
+## changelog-bot-action
+
+Runs on every PR merge to main. The workflow checks for changelog labels on the merged PR: `changelog - added`, `changelog - changed`, or `changelog - fixed`. If one is present, it runs [`changelog-tool`](https://github.com/ponylang/changelog-tool) to append an entry to `CHANGELOG.md` and pushes the commit.
+
+The push uses `GITHUB_TOKEN` deliberately. A changelog commit should not trigger further workflows. See [tokens and secrets](tokens-and-secrets.md) for why this matters.
+
+### Quirks
+
+The GitHub search API sometimes returns `totalCount: 0` even when results exist. The workaround is retries and reading `results[0]` directly instead of checking `totalCount`.
+
+Both the changelog bot and the [release notes bot](#release-notes-bot-action) may push to main at the same time after a PR merge. Both handle this with a pull-rebase-push retry loop — up to 5 retries with exponential backoff.
+
+## release-bot-action
+
+The core release automation. It is a single Docker image with multiple entrypoints, each invoked as a separate workflow step.
+
+The entrypoints:
+
+- `update-changelog-for-release`
+- `update-version-in-VERSION`
+- `trigger-artefact-creation`
+- `trigger-release-announcement`
+- `publish-release-notes-to-github`
+- `send-announcement-to-pony-zulip`
+- `add-announcement-to-last-week-in-pony`
+- `rotate-release-notes`
+
+See [release pipeline](release-pipeline.md) for how these steps chain together.
+
+## release-notes-bot-action
+
+Runs on every PR merge to main. The workflow checks for new files in `.release-notes/`.
+
+If the merged PR had a changelog label, the bot appends the contents of those files to `next-release.md` and deletes the individual files. If there was no changelog label, it just deletes them.
+
+Push-conflict handling is the same as the [changelog bot](#changelog-bot-action): a pull-rebase-push retry loop with up to 5 retries and exponential backoff.
+
+## release-notes-reminder-bot-action
+
+Runs when a changelog label is added to a PR. The workflow checks whether the PR already includes release notes files. If not, it posts a reminder comment.
+
+The bot uses a hidden HTML sentinel (`<!-- release-note-reminder-bot -->`) to avoid posting duplicate reminders on the same PR.
+
+## library-documentation-action-v2
+
+Generates library documentation using `ponyc` and `mkdocs`, then deploys to GitHub Pages via `actions/deploy-pages`. This replaces v1, which pushed to a `generated-documentation` branch.
+
+### Repo setup
+
+For this action to work, the target repo needs two settings:
+
+- GitHub Pages source must be set to "GitHub Actions" (not "Deploy from a branch").
+- The `github-pages` environment must allow deployment from all branches.

--- a/docs/contribute/ci/nightly-and-breakage-pipeline.md
+++ b/docs/contribute/ci/nightly-and-breakage-pipeline.md
@@ -1,0 +1,49 @@
+# Nightly and Breakage Pipeline
+
+A chain of events runs daily, starting from ponyc and reaching every library repo. Each step triggers the next. A nightly ponyc build triggers breakage tests across the org.
+
+## The nightly cascade
+
+### Step 1: ponyc nightly build
+
+A cron job runs `nightlies.yml` in the ponyc repo at midnight UTC. It builds ponyc for all release platforms and uploads packages to Cloudsmith and GHCR.
+
+### Step 2: Cloudsmith webhook
+
+When a package finishes syncing, Cloudsmith fires a webhook to ponyc's `cloudsmith-package-synchronised.yml`. That workflow dispatches platform-specific events to downstream repos (corral, ponyup, lori, and others) for macOS and Windows breakage tests.
+
+### Step 3: Docker image build
+
+The Alpine packages trigger `build-nightly-image.yml`, which builds the `ghcr.io/ponylang/ponyc:nightly` Docker image for x86-64 and arm64.
+
+### Step 4: Downstream dispatch
+
+After the Docker image is pushed, dispatch events go to `ponylang/shared-docker` and `ponylang/library-documentation-action-v2`.
+
+### Step 5: shared-docker rebuild
+
+`ponylang/shared-docker` rebuilds all builder images from the new ponyc nightly. When the rebuild finishes, it dispatches `shared-docker-builders-updated` to all downstream repos.
+
+### Step 6: Library breakage tests
+
+Each downstream repo runs its test suite against the nightly builder. Failures go to Zulip.
+
+See [triggered jobs](triggered-jobs.md) for the full list of dispatch events and their receivers.
+
+## Release image chain
+
+The same pattern runs for releases. A ponyc release triggers `ponyc-release-image-pushed`, which triggers `ponylang/shared-docker` to rebuild release builders, which triggers library breakage tests against the release. See the [release pipeline](release-pipeline.md) for the tag chain that starts a release.
+
+## Failure alerting
+
+Every scheduled and automated workflow includes a failure alert step. Alerts go to the Zulip `notifications` stream under the topic `<repo> unattended job failure`.
+
+PR workflows do not include failure alerts. A human is already watching.
+
+## Cloudsmith webhook auto-disable
+
+Cloudsmith auto-disables webhooks after repeated failures. When this happens, the nightly pipeline from Cloudsmith onward stops silently — zero workflow runs, zero alerts.
+
+`verify-nightly-image-freshness.yml` runs daily at 06:00 UTC in the ponyc repo. It checks that `ghcr.io/ponylang/ponyc:nightly` was updated within the last 36 hours. A stale nightly image means something upstream broke silently. This watchdog covers the Docker image path. The macOS and Windows paths through Cloudsmith have no equivalent watchdog.
+
+See [infrastructure](../infrastructure.md) for Cloudsmith admin access.

--- a/docs/contribute/ci/release-pipeline.md
+++ b/docs/contribute/ci/release-pipeline.md
@@ -1,0 +1,46 @@
+# Release Pipeline
+
+Releasing a ponylang project is a chain of three tag pushes. A human pushes the first tag. Each workflow pushes the tag that triggers the next. After that first push, the rest runs unattended. Each project's `RELEASE_PROCESS.md` has the human-facing steps for starting a release.
+
+Every step in the chain uses `RELEASE_TOKEN` to push its tag. `GITHUB_TOKEN` pushes do not trigger workflows — GitHub enforces this to prevent infinite loops. If any step uses `GITHUB_TOKEN` instead of `RELEASE_TOKEN`, the next workflow never runs and the release stalls with no error. See [tokens and secrets](tokens-and-secrets.md) for the full explanation.
+
+## Step 1: push release-X.Y.Z
+
+A committer pushes a `release-X.Y.Z` tag. This triggers `prepare-for-a-release.yml`, which:
+
+- Checks out main using `RELEASE_TOKEN`.
+- Runs `changelog-tool release` to version `CHANGELOG.md`.
+- Writes the version to `VERSION`.
+- Updates the version in `corral.json`.
+- Updates version references in `README.md`.
+- Pushes an `X.Y.Z` tag (using `RELEASE_TOKEN`, so it triggers step 2).
+- Adds a new "unreleased" section to `CHANGELOG.md`.
+- Deletes the `release-X.Y.Z` tag.
+
+## Step 2: X.Y.Z tag
+
+The `X.Y.Z` tag triggers `release.yml`, which:
+
+- Validates that `CHANGELOG.md` was properly versioned.
+- Creates an empty GitHub Release so build jobs can attach artifacts to it.
+- Builds artifacts. The specifics are project-dependent — compiling for all platforms, uploading to Cloudsmith.
+- For libraries: generates documentation and deploys to GitHub Pages.
+- Pushes an `announce-X.Y.Z` tag.
+
+## Step 3: announce-X.Y.Z tag
+
+The `announce-X.Y.Z` tag triggers `announce-a-release.yml`, which:
+
+- Publishes release notes and `CHANGELOG.md` to the GitHub Release.
+- Posts to the Zulip announce stream.
+- Comments on the open Last Week in Pony (LWIP) issue in ponylang/ponylang-website.
+- Rotates release notes (clears `.release-notes/next-release.md`).
+- Deletes the `announce-X.Y.Z` tag.
+
+## Concurrency protection
+
+Release workflows use a flat `"release"` concurrency key — one release at a time per repo. This prevents parallel runs from corrupting shared state: `CHANGELOG.md`, `VERSION`, and tags.
+
+## Action repos: the image swap
+
+Some repos are themselves GitHub Actions (changelog-bot-action, release-bot-action, and others). For these, the release process swaps `action.yml` to reference a prebuilt Docker image during step 2, then swaps it back during step 3. Without the swap, a Dockerfile dependency change after release breaks the action.

--- a/docs/contribute/ci/setting-up-a-new-repo.md
+++ b/docs/contribute/ci/setting-up-a-new-repo.md
@@ -1,0 +1,48 @@
+# Setting Up a New Repo
+
+Adding a new repository to the ponylang org requires CI, release automation, and breakage testing setup.
+
+## Secrets
+
+All standard secrets are org-level. A new repo in the ponylang org has access to them automatically — there is no repo-level secret setup unless the project has unique infrastructure (ponyc's playground server is the one current example).
+
+See [tokens and secrets](tokens-and-secrets.md) for the full secret inventory.
+
+## Workflow Setup
+
+Copy the workflow files from [ponylang/templates](https://github.com/ponylang/templates). Then customize:
+
+- `pr.yml` — set the container image and platform matrix for the project's build and test needs.
+- `release.yml` — configure artifact building. If the project produces binaries, add Cloudsmith upload steps. If it produces library documentation, add documentation generation.
+- `generate-documentation.yml` — set the library name and site URL.
+
+See [CI image organization](ci-image-organization.md) for available container images and naming conventions. Use any existing ponylang library repo (e.g., [ponylang/appdirs](https://github.com/ponylang/appdirs)) as a reference for typical configuration.
+
+The remaining workflow files need no project-specific changes.
+
+## GitHub Pages Setup
+
+Two settings are required for library documentation deployment:
+
+1. Set the GitHub Pages source to "GitHub Actions" (not "Deploy from a branch").
+2. Configure the `github-pages` environment to allow deployment from all branches.
+
+## Initialize Repo Files
+
+Create these files before the first release. Use any existing ponylang library repo as a template for the initial content.
+
+- `CHANGELOG.md`
+- `VERSION`
+- `.release-notes/next-release.md`
+- `.markdownlint.yml`
+- `.markdownlintignore`
+
+## Breakage Test Registration
+
+A new repo does not receive nightly breakage tests until it is registered in two places.
+
+**Linux breakage tests**: Add the repo to the dispatch matrix in `ponylang/shared-docker`'s `rebuild-ponyc-based-images.yml` — specifically the `send-builders-updated-event` job's `matrix.repo` list.
+
+**macOS and Windows breakage tests**: Add the repo to ponyc's `cloudsmith-package-synchronised.yml` dispatch list.
+
+See [nightly and breakage pipeline](nightly-and-breakage-pipeline.md) for how the cascade works.

--- a/docs/contribute/ci/standard-workflows.md
+++ b/docs/contribute/ci/standard-workflows.md
@@ -1,0 +1,73 @@
+# Standard Workflows
+
+Most ponylang repos use 14 workflow files copied from [ponylang/templates](https://github.com/ponylang/templates). They fall into four groups: PR checks, on-merge automation, release automation, and maintenance.
+
+## PR / CI workflows
+
+These run when a pull request is opened or updated.
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `pr.yml` | `pull_request` on code changes | Builds and tests on Linux (in a container), macOS, and Windows |
+| `pony-lint.yml` | `pull_request` on `.pony` files | Lints Pony source against nightly ponyc |
+| `pr-repo-hygiene.yml` | `pull_request` | Lints markdown, lints shell scripts, verifies `CHANGELOG` format |
+| `lint-action-workflows.yml` | `pull_request` | Lints GitHub Actions workflow YAML with actionlint |
+
+### Concurrency
+
+PR workflows use concurrency groups keyed on `github.ref` with `cancel-in-progress: true`. A new push to the same PR cancels the prior run.
+
+### Path filters
+
+The main build (`pr.yml`) excludes `*.md`, `*.yml`, and `*.yaml` from triggering it. The workflow file itself is re-included so that changes to the workflow still run the build.
+
+## On-merge workflows
+
+These run when a pull request merges to main. Each workflow invokes a custom GitHub Action maintained in its own repo — see [bot actions](bot-actions.md) for what those actions do internally.
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `changelog-bot.yml` | `push` to main | Updates `CHANGELOG.md` from merged PR labels |
+| `release-notes.yml` | `push` to main | Aggregates `.release-notes/` files into `next-release.md` |
+| `release-notes-reminder.yml` | `pull_request_target` (labeled) | Comments reminding the contributor to add release notes |
+
+## Release workflows
+
+These run during the three-tag release chain.
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `prepare-for-a-release.yml` | `release-X.Y.Z` tag | Versions `CHANGELOG.md`, writes `VERSION`, pushes the `X.Y.Z` tag |
+| `release.yml` | `X.Y.Z` tag | Builds artifacts, creates the GitHub Release |
+| `announce-a-release.yml` | `announce-X.Y.Z` tag | Publishes release notes, posts to Zulip, comments on the Last Week in Pony issue |
+| `generate-documentation.yml` | `workflow_dispatch` (manual) | Generates and deploys library documentation |
+
+See [release pipeline](release-pipeline.md) for how the three-tag chain works.
+
+## Maintenance workflows
+
+These run on schedules or in response to cross-repo dispatch events.
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `breakage-against-ponyc-latest.yml` | `repository_dispatch` | Tests the project against the latest nightly ponyc |
+| `add-discuss-during-sync.yml` | Issue/PR events | Adds the "discuss during sync" label |
+| `remove-discuss-during-sync.yml` | Issue/PR closed | Removes the "discuss during sync" label |
+
+Some repos split the breakage workflow into per-platform files (e.g., separate workflows for Linux, macOS, and Windows).
+
+See [nightly and breakage pipeline](nightly-and-breakage-pipeline.md) for how the nightly cascade dispatches these tests. See [CI image organization](ci-image-organization.md) for the Docker image naming and tagging conventions used across workflows.
+
+## Repos that diverge from the template
+
+### ponyc
+
+Beyond the standard workflows, ponyc has nightlies, tiered testing, stress tests, Docker image management, Cloudsmith webhook handling, LLVM libs-cache management, and playground updates. The PR workflow classifies changed files into suites and runs only the relevant tests.
+
+### ponylang-website
+
+No release workflows, no changelog bot, no nightlies. Instead it has `validate-site-on-pr.yml` and `verify-site-builds.yml`. Deployment is outside GitHub Actions.
+
+### shared-docker
+
+No release or changelog workflows. Has `rebuild-ponyc-based-images.yml` (rebuilds all CI builder images) and `build-linter-images.yml`.

--- a/docs/contribute/ci/tokens-and-secrets.md
+++ b/docs/contribute/ci/tokens-and-secrets.md
@@ -1,0 +1,45 @@
+# Tokens and Secrets
+
+## GITHUB_TOKEN vs. RELEASE_TOKEN
+
+GitHub provides a `GITHUB_TOKEN` automatically for every workflow run. It can read and write the current repo. But pushes made with `GITHUB_TOKEN` do not trigger other workflows. GitHub enforces this to prevent infinite loops.
+
+The ponylang release pipeline is a chain of tag pushes, each triggering the next workflow. If any step pushes a tag with `GITHUB_TOKEN`, the next workflow never runs. No error, no alert — the chain stops silently.
+
+`RELEASE_TOKEN` is a personal access token (classic, `public_repo` scope) owned by the Ponylang Main Bot account. Pushes made with `RELEASE_TOKEN` do trigger other workflows, so the release chain can proceed from step to step.
+
+The changelog bot is the reverse case. When it pushes a CHANGELOG update to main, that push should not trigger itself again. `GITHUB_TOKEN` is correct there.
+
+## The bot account
+
+Ponylang Main Bot is a regular GitHub account, not a GitHub App. All PATs used across the org are owned by this account. Automated commits use the name "Ponylang Main Bot" and the email `ponylang.main@gmail.com`.
+
+See [infrastructure](../infrastructure.md) for more about the bot account.
+
+## Secret inventory
+
+All secrets except the `PLAYGROUND_*` group are org-level — available to every repo in the ponylang org automatically. No per-repo setup is needed for standard workflows.
+
+| Secret | What it is | What it's for |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | Automatic, per-run | GitHub Container Registry (GHCR) login, package read/write, checkout, bot pushes that should not trigger further workflows |
+| `RELEASE_TOKEN` | PAT, `public_repo` scope | Release tag chain, GitHub Release publishing, Last Week in Pony (LWIP) posting, release artifact uploads |
+| `PONYLANG_MAIN_API_TOKEN` | PAT, cross-repo scope | `repository_dispatch` events to other repos, "discuss during sync" label automation, release notes reminder bot |
+| `CLOUDSMITH_API_KEY` | API key | Uploading release and nightly packages to Cloudsmith. Only repos with distributable binaries (ponyc, corral, ponyup, changelog-tool) |
+| `PONYLANG_MAIN_DELETE_PACKAGE_TOKEN` | PAT, `delete:packages` scope | Pruning old nightly Docker images from GHCR (>90 days) |
+| `PONYLANG_MAIN_READ_PACKAGE_TOKEN` | PAT, `read:packages` scope | Reading packages cross-repo for libs-cache management (ponyc only) |
+| `ZULIP_SCHEDULED_JOB_FAILURE_API_KEY` | Zulip bot credential | Posting failure alerts to the notifications stream |
+| `ZULIP_SCHEDULED_JOB_FAILURE_EMAIL` | Zulip bot credential | Paired with `ZULIP_SCHEDULED_JOB_FAILURE_API_KEY` |
+| `ZULIP_RELEASE_API_KEY` | Zulip bot credential | Posting release announcements to the announce stream |
+| `ZULIP_RELEASE_EMAIL` | Zulip bot credential | Paired with `ZULIP_RELEASE_API_KEY` |
+| `PLAYGROUND_HOST` | SSH hostname | SSH into the Pony Playground server after release image builds. ponyc only, repo-level |
+| `PLAYGROUND_ADMIN_USER` | SSH username | Paired with `PLAYGROUND_HOST` |
+| `PLAYGROUND_KEY` | SSH private key | Paired with `PLAYGROUND_HOST` |
+
+## Fork PRs and secrets
+
+Pull requests from forks get a read-only `GITHUB_TOKEN`. This is a GitHub security feature. Forks have no access to org secrets.
+
+PR CI tests are designed to work without custom secrets. If a workflow requires custom secrets to run PR tests, that is a bug.
+
+One practical consequence: fork PRs against ponyc cannot write to the GHCR libs cache, so they rebuild LLVM from scratch instead of using the cache.

--- a/docs/contribute/infrastructure.md
+++ b/docs/contribute/infrastructure.md
@@ -48,7 +48,7 @@ Members have [owner level](https://docs.github.com/en/github/setting-up-and-mana
 
 #### [ponylang-main](https://github.com/ponylang-main)
 
-Our standard "bot account". Personal access tokens for our various GitHub action powered bots are from this account; as such, it shows up as a contributor on a variety of Pony projects.
+Our standard "bot account". Personal access tokens for our various GitHub action powered bots are from this account; as such, it shows up as a contributor on a variety of Pony projects. See [tokens and secrets](ci/tokens-and-secrets.md) for what each token does.
 
 #### [ponylang-gists](https://github.com/ponylang-gists)
 

--- a/docs/contribute/releases.md
+++ b/docs/contribute/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-All ponylang projects have automated release processes. The detailed steps for releasing any given project are in the `RELEASE_PROCESS.md` file in the root of that project's repository.
+All ponylang projects have automated release processes. A human pushes a tag; the rest is automated. See [release pipeline](ci/release-pipeline.md) for how the three-tag chain works. The detailed steps for releasing any given project are in the `RELEASE_PROCESS.md` file in the root of that project's repository.
 
 A "triggers release" label marks bugs that affect runtime correctness — memory leaks, memory safety issues, crashes, or anything else that is degenerate for running programs. When a fix for one of these lands, a release happens as soon as safely possible rather than waiting for the next scheduled release.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,12 @@ nav:
       - Project Operations:
           - CI:
               - Overview: "contribute/ci.md"
+              - Tokens and Secrets: "contribute/ci/tokens-and-secrets.md"
+              - Standard Workflows: "contribute/ci/standard-workflows.md"
+              - Release Pipeline: "contribute/ci/release-pipeline.md"
+              - Nightly and Breakage Pipeline: "contribute/ci/nightly-and-breakage-pipeline.md"
+              - Bot Actions: "contribute/ci/bot-actions.md"
+              - Setting Up a New Repo: "contribute/ci/setting-up-a-new-repo.md"
               - CI Image Organization: "contribute/ci/ci-image-organization.md"
               - GitHub Actions and Security: "contribute/ci/gh-actions-security.md"
               - ponyc CI Tiers: "contribute/ci/ponyc-ci-tiers.md"


### PR DESCRIPTION
Six new pages under Contribute > CI documenting the GitHub Actions infrastructure: how tokens and secrets work (the GITHUB_TOKEN vs RELEASE_TOKEN distinction and the full secret inventory), what the 14 standard template workflows do, the three-tag release chain, the nightly-to-breakage cascade, the five custom bot actions, and how to set up a new repo from scratch.

The overview page and nav are updated to include the new pages. Cross-references added to the releases and infrastructure pages.

Written from the research in #937.

### Parked items from docs review

These came up during the review ensemble. I fixed the unambiguous ones; these need your input:

1. **PONYLANG_MAIN_API_TOKEN scope**: The table says "PAT, cross-repo scope" but other PATs specify their actual GitHub permission scope (e.g., `public_repo`, `delete:packages`). I don't have the actual scope for this one. Should it be verified and updated?

2. **Release stall recovery**: The release pipeline page explains what causes a stall (wrong token) but doesn't say how to recover from one. Should it include recovery steps, or is that out of scope for an overview page?

3. **GitHub Pages setup duplication**: The same two bullet points about GitHub Pages configuration appear in both bot-actions.md (under library-documentation-action-v2) and setting-up-a-new-repo.md. Keep both for independent entry points, or make one canonical and cross-reference from the other?

4. **Workflow copy mechanics**: setting-up-a-new-repo.md says "Copy the workflow files from ponylang/templates" without specifying which files or how. A reader setting up a new repo would need to check another repo to figure out the mechanics. Should this be more specific?
