### PR TITLE
Update operator-spacing rule for continuation line convention

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -58,7 +58,7 @@ corral run -- pony-lint src/ test/
 | `style/match-no-single-line` | on | Match expressions must span multiple lines |
 | `style/member-naming` | on | Member names should be snake_case |
 | `style/method-declaration-format` | on | Multiline method declaration formatting (parameter layout, return type and `=>` alignment) |
-| `style/operator-spacing` | on | Binary operators need surrounding spaces; no space after unary `-` |
+| `style/operator-spacing` | on | Binary operators need surrounding spaces and belong at line end; no space after unary `-` |
 | `style/package-docstring` | on | Package should have a `<package>.pony` file with a docstring |
 | `style/package-naming` | off | Package directory name should be snake_case |
 | `style/partial-call-spacing` | on | `?` at call site must immediately follow `)` |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -703,7 +703,7 @@ actor Foo
 
 **Default:** on
 
-Checks whitespace around operators per the style guide. Binary operators require a space before and after. The `not` keyword requires a space after; before `not`, either a space or a non-alphanumeric character (e.g., `(`) is acceptable. Unary minus must NOT have a space after the `-`. The "before" check is skipped on continuation lines where the operator is the first non-whitespace character.
+Checks whitespace and placement of operators per the style guide. Binary operators require a space before and after, and belong at the end of a line when an expression spans multiple lines. A binary operator at the start of a continuation line is flagged. The `not` keyword requires a space after; before `not`, either a space or a non-alphanumeric character (e.g., `(`) is acceptable. Unary minus must not have a space after the `-`. At the start of a line, `- expr` with a space is flagged because the Pony parser treats `-` there as negation, not subtraction.
 
 **Incorrect:**
 
@@ -712,6 +712,10 @@ let x = 1+2
 let y = a ==b
 if not(x) then -a end
 let z = - a
+
+// Binary operator at start of continuation line
+let w = a
+  + b
 ```
 
 **Correct:**
@@ -721,9 +725,9 @@ let x = 1 + 2
 let y = a == b
 if not x then -a end
 
-// Continuation lines are fine
-let z =
-  + a
+// Operator at end of line
+let w = a +
+  b
 ```
 
 ## `style/package-naming`


### PR DESCRIPTION
The operator-spacing lint rule now flags binary operators at the start of continuation lines. The Pony parser treats `-` at line start as unary negation, not subtraction, so the old convention (operators at line start) was a semantic footgun. The style guide and linter were updated in ponylang/ponyc#5851.

Updates the rule summary table in `linting.md` and the detailed entry in `rule-reference.md` to match the new behavior.
