### PR TITLE
Remove rfc-tool references from CI docs

### DIFF
--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -17,7 +17,6 @@ The scheduled jobs list was last updated June 28, 2026.
 | ponyc: prune branch libs cache | 04:37 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: verify nightly image freshness | 06:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyup: nightly build | 00:00 | [ponylang/ponyup](https://github.com/ponylang/ponyup) |
-| rfc-tool: nightly build | 00:00 | [ponylang/rfc-tool](https://github.com/ponylang/rfc-tool) |
 | ponylang-website: verify site builds | 02:00 | [ponylang/ponylang-website](https://github.com/ponylang/ponylang-website) |
 | pony-patterns: verify site builds | 02:00 | [ponylang/pony-patterns](https://github.com/ponylang/pony-patterns) |
 | pony-tutorial: verify site builds | 02:00 | [ponylang/pony-tutorial](https://github.com/ponylang/pony-tutorial) |

--- a/docs/contribute/ci/triggered-jobs.md
+++ b/docs/contribute/ci/triggered-jobs.md
@@ -106,7 +106,6 @@ Sent after our various Linux builders hosted in the shared-docker repo have been
 - [reactive_streams: breakage-against-ponyc-latest](https://github.com/ponylang/reactive_streams/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [redis: breakage-against-ponyc-latest](https://github.com/ponylang/redis/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [regex: breakage-against-linux-ponyc-latest](https://github.com/ponylang/regex/blob/main/.github/workflows/breakage-against-linux-ponyc-latest.yml)
-- [rfc-tool: breakage-against-ponyc-latest](https://github.com/ponylang/rfc-tool/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [semver: breakage-against-ponyc-latest](https://github.com/ponylang/semver/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [ssl: breakage-against-linux-ponyc-latest](https://github.com/ponylang/ssl/blob/main/.github/workflows/breakage-against-linux-ponyc-latest.yml)
 - [stallion: breakage-against-ponyc-latest](https://github.com/ponylang/stallion/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)


### PR DESCRIPTION
The ponylang/rfc-tool repo has been archived. Removes its entries from the triggered jobs and scheduled jobs CI documentation.