### PR TITLE
Note that small machine words skip boxing on 64-bit platforms

### DIFF
--- a/docs/use/performance/pony-performance-cheat-sheet.md
+++ b/docs/use/performance/pony-performance-cheat-sheet.md
@@ -197,6 +197,8 @@ type Money is (Dollars, Cents)
 
 Machine words like U8, U16, U32, U64, etc. are going to be better for performance than classes. Machine words have less overhead than classes. However, if we aren't careful, we can end up "boxing" machine words and add cost. In hot path code, that boxing can have a large impact.
 
+On 64-bit platforms, machine words that fit in 32 bits or fewer — Bool, U8, I8, U16, I16, U32, I32, and F32 — are encoded directly in the pointer value when they appear in a union type, so no heap allocation happens. On Windows (LLP64), ILong and ULong are also 32-bit and get the same treatment. The boxing cost described below applies to the remaining types: U64, I64, U128, I128, USize, F64, and on LP64 platforms (Linux, macOS) ILong and ULong.
+
 The easiest way to end up boxing a machine word is by including it in a union type. Take a look at the following code:
 
 ```pony


### PR DESCRIPTION
The "Avoid boxing machine words" section of the performance cheat sheet tells readers that putting machine words in union types causes heap allocation. With ponyc's tagged-pointer encoding (ponylang/ponyc#5952), machine words that fit in 32 bits or fewer — Bool, U8, I8, U16, I16, U32, I32, and F32 — are encoded directly in the pointer value on 64-bit platforms, so no heap allocation happens. The boxing cost now only applies to the larger types: U64, I64, USize, F64, U128, and I128.

Adds a paragraph noting this before the existing examples, which still use USize (64 bits on 64-bit platforms) and remain correct.
