### PR TITLE
Add FAQ entry for when Pony will reach 1.0

### DIFF
--- a/docs/faq/about-pony.md
+++ b/docs/faq/about-pony.md
@@ -28,6 +28,12 @@ Many of us who are regular contributors share some general goals as we move towa
 
 We invite you to join our small but growing community and help push Pony forward. We're still at an early stage, and new community members can have a huge influence on the language. Join us!
 
+## When will Pony reach version 1.0? {:id="when-1-0"}
+
+Not before late 2027 at the earliest. We're actively developing a number of features that need to stabilize first, and we want real-world usage time with those features before committing to 1.0. Minting a stable release means breaking changes become a much bigger deal — we'd rather get it right than get it early.
+
+You can follow development progress in [Last Week in Pony](/blog/categories/last-week-in-pony/) or ask questions on our [Zulip community](https://ponylang.zulipchat.com).
+
 ## Are there any examples of something complex built in Pony? {:id="real-world-pony-codebases"}
 
 Yes! Here's a few projects we regularly point people towards:


### PR DESCRIPTION
Add a "When will Pony reach version 1.0?" entry to the About Pony FAQ. Sets expectations — not before late 2027 — and explains why: features need to stabilize and get real-world usage before we commit to a stable release. Links to LWIP and Zulip for people who want to follow along or ask questions.
