### PR TITLE
Remove mention of good first issues being posted to Zulip

### DIFF
--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -33,6 +33,5 @@ The scheduled jobs list was last updated June 28, 2026.
 | ponyc: stress test (Windows generative, normal) | 02:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | lori: stress tests | 06:30 | [ponylang/lori](https://github.com/ponylang/lori) |
 | ponyc: test with latest tools | 12:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
-| pony-sync-helper: post good first issues | 14:00 Mon | [ponylang/pony-sync-helper](https://github.com/ponylang/pony-sync-helper) |
 
 <!-- markdownlint-restore -->

--- a/docs/contribute/good-first-issues.md
+++ b/docs/contribute/good-first-issues.md
@@ -2,8 +2,6 @@
 
 Across that various repositories that make up the [Ponylang project](https://github.com/ponylang/), some issues get marked as good for folks getting started contributing to Pony. The general idea behind the "good first issue" label is to make it simple for people to find issues that should be easy to get started with. Generally such issues are well defined and don't require a deep understanding of the codebase to get started.
 
-Every week, we post a list of all open "good first issue" tickets from across all of our repositories. You can find the latest list in the [#contribute to Pony](https://ponylang.zulipchat.com/#narrow/stream/192795-contribute-to-Pony) channel in the [Pony Zulip](https://ponylang.zulipchat.com).
-
 Pony is a volunteer project and we welcome contributions from everyone. We are happy to help you get started contributing to Pony. If you have any questions about any of the issues, feel free to ask in the [#contribute to Pony](https://ponylang.zulipchat.com/#narrow/stream/192795-contribute-to-Pony) channel in the [Pony Zulip](https://ponylang.zulipchat.com).
 
 Every little commit helps and "good first issue" tickets are a great way to assist the project with a small time commitment.


### PR DESCRIPTION
The automated job that posts good first issues to Zulip is being removed. This removes the mention of the weekly posting from the good first issues page and the scheduled jobs table.